### PR TITLE
Expand agent playbook with role protocols

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,153 @@
+# Agent Playbook
+
+## Executive Summary — Follow These First
+1. **Respect the architecture.** This is a Next.js 14 App Router app on Node 20+/TypeScript 5.9 with Prisma 6.16 + Postgres. Keep server-only code under `src/server/**`, rely on the `@/` alias, and never create ad-hoc Prisma clients.
+2. **Preserve domain invariants.** Work Orders move sequentially from `PLANNED` → … → `CLOSED`, `CANCELLED` remains available, and every mutation must write both a `WorkOrderVersion` snapshot and an `AuditLog` entry.
+3. **Keep data deterministic.** Treat `backup-data.ts` as the source of truth: reseeding wipes runtime additions. Align `prisma/schema.prisma`, migrations, `src/db/seed.ts`, and `backup-data.ts` before shipping.
+4. **Validate and test.** Use `zod` for all API payloads and run `npm run test` (Vitest) before requesting review. Add contract/unit/E2E coverage when you touch corresponding layers.
+5. **Document the change.** Update `docs/ONBOARDING.md` if flows/setup shift and append a UTC entry to `docs/CHANGELOG.md` with agent, timestamp, summary, and reasoning.
+
+## Purpose & Context
+One file that tells agents (and humans) how this MVP works, who owns what, how handoffs occur, and what “done” means—aligned to this repo.
+
+- **Domain:** High-mix/low-volume boat factory operations managing the full Work Order (WO) lifecycle with routing versioning.
+- **Roles:** `ADMIN`, `SUPERVISOR`, and `OPERATOR` with RBAC enforced across UI and API layers.
+- **Key systems:** Notes timeline, file management, model/trim selector, routing (default/new/saved versions), and audit trails.
+- **Default routing path:** `Kitting → Lamination → Hull Rigging → Deck Rigging → Capping → Engine Hang → Final Rigging → Water Test → QA → Cleaning → Shipping`.
+- **Seeds & persistence:** `backup-data.ts` is the canonical dataset. Reseeds delete runtime records; keep long-lived fixtures mirrored there.
+
+## Stack & Runtime Guardrails
+- Next.js 14 App Router, TypeScript 5.9, Node.js 20+, default port `5000`.
+- Prisma 6.16 with Postgres; middleware logs audit metadata.
+- Vitest with test files under `src/**/__tests__/`.
+- Path alias `@/` is mandatory for `src/` imports.
+- Server-only code resides in `src/server/**` (Prisma, storage, business logic). Never import it into client components.
+- API handlers live in `src/app/api/**/route.ts` and must return `NextResponse.json({ ok, data?, error? })`.
+- Auth: JWT stored in HTTP-only cookies, hashed credentials with `bcryptjs`, RBAC enforced in middleware/handlers.
+- Environment keys belong in `src/lib/env.ts` and `.env.example`. Current required keys: `DATABASE_URL`, `JWT_SECRET`, `STORAGE_BUCKET_ID`, `NODE_ENV`.
+- Formatting: run Prettier 3 (`npx prettier@3 --write <files>`) on touched files.
+
+## Domain Rules & Invariants
+- **Work Orders:**
+  - Status pipeline includes `PLANNED` through closure plus `CANCELLED`.
+  - Stage progression is sequential; operators only see work scoped to their department.
+  - Each mutation writes a `WorkOrderVersion` (with `id`, `workOrderId`, `versionNumber`, `snapshotData` JSON, `createdBy`, `createdAt`, `reason`) and an `AuditLog` entry. Include `schema_hash` and `versionNumber` in the snapshot payloads.
+- **Routing:**
+  - Default routing must reference all 11 departments above.
+  - Saved versions support create/read/update/delete with consistent naming and retrieval semantics.
+  - Creating a WO blocks until routing validates that every department has an active work center.
+- **Notes & Timeline:**
+  - Use a single `Note` model with `(entity_type, entity_id, author_role)`.
+  - Timeline views combine notes, status changes, and file events ordered chronologically with department scoping.
+- **Files & Storage:**
+  - Use the configured `STORAGE_BUCKET_ID`; avoid hardcoded IDs or ad-hoc ACLs.
+  - JWT payload uses `user.userId` (not `user.id`). Ensure uploads → storage → DB records stay consistent. Bulk operations must honor permissions.
+- **Real-time & Performance:**
+  - Poll endpoints roughly every 10 seconds; keep them idempotent and cache-friendly.
+  - Dashboard initial load target < 1.5s on seeded data; WO detail APIs < 800ms. Prefer Prisma `_count`/aggregations and avoid N+1 queries.
+- **Security:**
+  - Never log secrets. JWT stays cookie-only. Enforce RBAC and department scoping in every handler. Only Supervisors can edit routing while a WO is `PLANNED`. All denied writes should produce audit attempts.
+
+## Data Management Workflow
+1. Update `prisma/schema.prisma` first, then run `npm run prisma:migrate` followed by `npm run prisma:generate`.
+2. Sync fixtures in `src/db/seed.ts` and persist reference data in `backup-data.ts`.
+3. Use `npm run seed:dry` to preview and `npm run seed` to apply deterministic seeds.
+4. Include model/trim coverage (e.g., LX24 Base/Sport/Luxury; LX26 Base/Sport/Luxury/Premium) and sample WOs across statuses.
+
+## Testing Expectations
+- **Baseline:** `npm run test` must pass before submission.
+- **Contract tests:** Add/update Vitest contract suites for any touched API route.
+- **Unit tests:** Cover validators, snapshot writers, routing logic, etc.
+- **E2E (when present):** Exercise happy paths for supervisor routing flows, operator dashboards, file management, and cancellation handling.
+- **Performance checks:** Spot-check that critical endpoints remain within the performance targets above.
+
+## Documentation & Change Management
+- Update `docs/ONBOARDING.md` whenever setup steps, env variables, or major flows change.
+- Maintain `docs/CHANGELOG.md` with newest entry first, including agent name, ISO 8601 UTC timestamp, summary, and reasoning per PR.
+- Keep ADRs under `docs/adr/` current; add new ones when architecture decisions shift.
+
+## Operational Protocol
+- **Task Spec Template**
+  ```yaml
+  task: "Routing defaults & validation"
+  owner: "Routing & Work Centers"
+  context:
+    related_issues: [#123]
+    risk: "Medium — block create WO until valid routing"
+  acceptance_criteria:
+    - Default 11-dept routing applies when selected
+    - Create New Routing saves version; appears in Saved list
+    - Validation blocks create until all 11 depts have active work centers
+  test_plan:
+    contract:
+      - "POST /api/work-orders validates routing"
+      - "GET /api/work-centers returns active entries"
+    unit:
+      - "routing validator"
+      - "version save"
+    e2e:
+      - "create WO with default routing succeeds"
+      - "invalid routing blocked with clear error"
+  rollback:
+    - "revert migration N; keep backup of backup-data.ts snapshot"
+  artifacts:
+    - "schema diff"
+    - "screenshots/gifs of flows"
+  ```
+- **Solo agents:** If you are the only agent on a task, you may assume multiple roles below. Explicitly note which hats you wore in the changelog entry.
+- **Handoffs:** When passing work, summarize progress, outstanding risks, and relevant test results. Reference the task spec in your PR description.
+
+## Role Playbook & Ownership Labels
+For multi-agent efforts, align work with the primary owner. Solo agents should still follow the expectations for each area they touch.
+
+1. **Product Architect** (`domain`)
+   - Owns domain model, invariants, ADRs. Outputs include ADRs in `docs/adr/`, schema diffs, migration plans. Done when ADR merged and migrations unblock others.
+2. **DB Migration & Versioning** (`schema-change`)
+   - Maintains schema evolution, WO snapshots, audit integrity. Ensures `priority` enum (`LOW`, `NORMAL`, `HIGH`, `CRITICAL`) and `WOStatus` includes `CANCELLED`. Verifies `WorkOrderVersion` hooks for create/update/status. Done when migrations succeed up/down, seeds align, and rollback instructions exist.
+3. **API & Contracts** (`api-contract`)
+   - Builds typed, zod-validated handlers with stable response contracts. Done when contract tests cover all changed routes.
+4. **UI/UX Implementer** (`role-ui`)
+   - Delivers role dashboards and detail flows without raw JSON forms. Supervisor must create WOs, pick routing (Default/New/Saved), save milestones, and use unified timeline. Operator dashboard handles queues, START/PAUSE/COMPLETE, notes, attachments with department scope. Board (Kanban) and Table share headers; Create Work Order buttons visible. Done when UX checklist and E2E happy paths (if available) pass.
+5. **Notes & Timeline Unifier** (`notes-timeline`)
+   - Maintains single notes system + cross-entity timeline; removes legacy paths; migrates data safely. Done when history preserved and old tables removed.
+6. **Routing & Work Centers** (`routing`)
+   - Ensures default routing, saved versions, validation. Done when WO creation blocks invalid routing and version CRUD validated.
+7. **Files & Storage** (`files`)
+   - Handles upload/list/search/bulk flows with stable ACLs. Confirms JWT user id usage and end-to-end storage integrity. Done when bulk ops tested.
+8. **Data Fixtures & Seeding** (`seed`)
+   - Produces deterministic dev/E2E data aligned with `backup-data.ts`. Done when environment bootstraps from zero via one command.
+9. **QA & Release Gate** (`qa-gate`)
+   - Enforces Definition of Done: `tsc` clean, Prettier applied, tests green, migrations up/down, perf sanity, E2E (if configured).
+10. **Security & Permissions** (`security`)
+    - Oversees JWT/cookie, RBAC, department scoping. Ensures only Supervisors edit routing while WO is `PLANNED`, operators restricted appropriately, every write audited, and denial cases tested.
+11. **Docs & Runbooks** (`docs`)
+    - Keeps documentation in sync: `AGENTS.md`, `API_CONTRACT.md`, `MIGRATIONS.md`, `docs/ONBOARDING.md`, `docs/CHANGELOG.md`. Done when docs updated alongside code.
+
+## PR Checklist
+- ☐ Prettier 3 run on touched files.
+- ☐ `npm run prisma:migrate` (if schema changed) and `npm run prisma:generate` succeed.
+- ☐ Seeds updated (`src/db/seed.ts`) and `backup-data.ts` adjusted if reference data changed.
+- ☐ Contract/unit/E2E tests updated or added for affected areas.
+- ☐ Docs refreshed (including ONBOARDING/CHANGELOG) and changelog entry added with UTC timestamp.
+- ☐ Performance/accessibility baselines still met; call out deviations in the PR.
+
+## Core Flows to Validate Before Shipping
+- Supervisor creates `PLANNED` WO → selects Default/New/Saved routing → saves version → releases.
+- Operator dashboard: pick `READY` WO → `START`/`PAUSE`/`COMPLETE` → add note and file (department scoped).
+- Board (Kanban) and Table views share headers; `Create Work Order` button accessible.
+- Timeline displays unified notes/status/file events with counts.
+- Cancelling a WO records snapshot + audit and surfaces correctly in UI filters.
+- Full reseed from zero: models/trims and WOs reappear; no data silently lost.
+- File management: upload → list/search → bulk delete using `user.userId`.
+
+## Ready-Made Prompts (Repo-Aware)
+- “Fix routing validation end-to-end” — Add `zod` schemas for routing payloads, enforce 11 departments with active work centers in `POST /api/work-orders`, surface actionable UI errors, and cover with contract/unit/UI tests.
+- “Unify notes & timeline” — Migrate to single `Note` model, build timeline union (notes/status/files), remove legacy paths, and test contract/unit/UI flows.
+- “Snapshot writer & audit” — Ensure snapshots on WO create/update/status change include `schema_hash` and `versionNumber`. Cover with unit + contract tests.
+
+## Definition of Done
+- Code, migrations, and seeds merged without regressions.
+- API contracts verified with Vitest suites and remain backwards compatible.
+- Seeds and `backup-data.ts` updated to reflect new truths.
+- Documentation updated (`AGENTS.md`, onboarding, ADRs, changelog, etc.).
+- Changelog entry appended with reasoning and timestamp.

--- a/README.md
+++ b/README.md
@@ -1,112 +1,70 @@
 # Boat Factory Operations MVP
 
-Next.js 14 Operations MVP for high-mix, low-volume boat factory.
+Next.js 14 operations platform supporting a high-mix, low-volume boat factory. The app coordinates what operators execute on the floor and how supervisors plan, release, and monitor work.
 
-## Features
+## Product Features
 
-### Operator Console (Interactive)
-- **Work Order Queue**: Real-time view of READY and IN_PROGRESS work orders
-- **Search**: Find work orders by WO number or Hull ID
-- **Stage Actions**: Start, Pause, and Complete operations with quantity tracking
-- **Station Selection**: Persisted station assignment
-- **Department Scoped**: Operators only see/act on their department's work
-- **Auto-refresh**: Queue updates every 5 seconds
+### Operator Console
 
-### Supervisor Dashboard (Interactive)
-- **Board Tab**: 
-  - Table/Kanban view toggle for work orders
-  - Real-time KPIs (Released, In Progress, Completed, On Hold)
-  - Hold/Unhold work orders with reason tracking
-  - Detail drawer with full stage timeline
-- **Plan Tab**:
-  - Create new work orders with routing configuration
-  - Clone and edit routing versions
-  - Enable/disable stages, reorder, adjust standard times
-  - Release work orders to production
-- **Department Filter**: Admins can view all departments
+- Real-time queue of READY and IN_PROGRESS work orders scoped to the operator's department, refreshed every five seconds.
+- Search across work orders by number or hull ID and open any result directly from the queue.
+- Guided action panel for the active stage with persisted station selection, quantity capture, and Start/Pause/Complete controls.
+- Department picker for multi-skilled operators, backed by role-aware authentication and redirects.
 
-### Core Systems
-- **Authentication**: JWT httpOnly cookies with role-based redirects
-- **Stage Gating**: Only current enabled stage is actionable
-- **Audit Logging**: Complete traceability of all actions
-- **Database**: PostgreSQL with Prisma ORM
-- **Department Scoping**: All operations filtered by user's department
+### Supervisor Workspace
 
-## Quick Start
+- Single workspace that merges planning and execution views with a table/Kanban toggle, live KPI cards, and department filtering for administrators.
+- Detail drawer that surfaces the entire stage timeline, operator notes, file attachments, and version history in dedicated tabs.
+- Integrated routing editor to enable/disable stages, reorder sequences, adjust standard times, and persist new routing versions for reuse.
+- Work-order creation modal with model/trim selection, automatic SKU generation, and the ability to clone or reuse existing routings before release.
+- Hold, unhold, and release actions with reason tracking to control production flow without leaving the workspace.
 
-1. **Install dependencies**:
+### Platform Capabilities
+
+- JWT-backed authentication with httpOnly cookies and role-based redirects between operator, supervisor, and admin experiences.
+- Prisma/PostgreSQL data layer with audit history, notes, and attachments for end-to-end traceability.
+- Department-aware stage gating so only the current enabled stage is actionable and recorded.
+- Shared component library for stats, data grids, notes timelines, and file management to keep UI patterns consistent.
+
+## Getting Started
+
+Follow `docs/ONBOARDING.md` for environment prerequisites and secrets management, then:
+
+1. **Install dependencies**
    ```bash
    npm install
    ```
-
-2. **Generate Prisma client**:
+2. **Generate the Prisma client**
    ```bash
-   npx prisma generate
+   npm run prisma:generate
    ```
-
-3. **Run database migration**:
+3. **Apply database migrations**
    ```bash
-   npx prisma migrate dev --name init
+   npm run prisma:migrate -- --name init
    ```
-
-4. **Seed the database**:
+4. **Seed the database with demo data**
    ```bash
    npm run seed
    ```
-
-5. **Start development server**:
+5. **Start the development server (defaults to port 5000)**
    ```bash
    npm run dev
    ```
 
-## Test Accounts
+## Testing
+
+- Run the Vitest suite before opening a pull request:
+  ```bash
+  npm run test
+  ```
+
+## Reference Accounts
 
 - **Admin**: admin@cri.local / Admin123!
 - **Supervisor**: supervisor@cri.local / Supervisor123!
 - **Operator**: operator@cri.local / Operator123!
 
-## Architecture
+## Documentation & Change Tracking
 
-- **Frontend**: Next.js 14 App Router with TypeScript
-- **Backend**: Next.js API routes
-- **Database**: PostgreSQL with Prisma
-- **Authentication**: JWT with httpOnly cookies
-- **Authorization**: Role-based access control (RBAC)
-
-## Database Schema
-
-- **Users**: Admin, Supervisor, Operator roles
-- **Departments**: One per manufacturing stage
-- **Work Centers & Stations**: Manufacturing resources
-- **Routing Versions**: Product routing definitions
-- **Work Orders**: Production orders with stage tracking
-- **Audit Logs**: Complete change history
-
-## Usage Notes
-
-### For Operators
-1. Login with your operator credentials
-2. Your department's work queue loads automatically
-3. Search for specific work orders using WO number or Hull ID
-4. Click "Open" on any queue item or search result to view the action panel
-5. Select your station (persisted between sessions)
-6. Enter quantities and optional notes
-7. Use Start/Pause/Complete buttons to manage work progress
-8. Queue refreshes automatically every 5 seconds
-
-### For Supervisors
-1. Login with supervisor credentials
-2. **Board Tab** - Monitor work in progress:
-   - Toggle between Table and Kanban views
-   - Put work orders on hold (with reason) or release from hold
-   - Click "Open" to see detailed stage timeline and notes
-3. **Plan Tab** - Create and manage work orders:
-   - Click "Create Work Order" to define new production
-   - Configure routing by enabling/disabling stages
-   - Reorder stages and adjust standard times
-   - Release planned work orders to start production
-
-### For Administrators
-- All supervisor features plus:
-- Department filter to view/manage all departments
-- Access to all work orders across the factory
+- Developer onboarding instructions live in `docs/ONBOARDING.md`.
+- Each agent must append their work to `docs/CHANGELOG.md` with a timestamp, summary, and reasoning.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Agent Change Log
+
+> Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
+
+## 2025-10-08T16:05:00Z — Agent: gpt-5-codex
+
+- **Summary:** Replaced the lightweight guidance with a comprehensive `AGENTS.md` playbook that adds an executive summary, role protocols, and reinforced domain/operational guardrails.
+- **Reasoning:** Give future agents a scannable yet thorough reference so they can uphold the product invariants, testing discipline, and documentation habits without guesswork.
+
+## 2025-10-08T15:18:59Z — Agent: gpt-5-codex
+
+- **Summary:** Refreshed the project README to document the combined supervisor workspace, current operator capabilities, and up-to-date setup/testing guidance.
+- **Reasoning:** Align the public-facing documentation with the latest product experience and developer workflow.
+
+## 2025-10-08T14:20:00Z — Agent: gpt-5-codex
+
+- **Summary:** Added the root `AGENTS.md` to codify coding standards, testing requirements, and documentation expectations. Established the shared change log process.
+- **Reasoning:** Provide future agents with clear guardrails and traceability for their work.


### PR DESCRIPTION
## Summary
- replace the lightweight guidance with an expanded `AGENTS.md` that opens with an executive summary and details architecture, domain invariants, and operational guardrails
- document role ownership, solo-agent expectations, handoff protocol, and ready-made prompts for future workstreams
- add a changelog entry capturing the new playbook and its rationale

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e55f0151948320bfa85501335ae199