### PR TITLE
feat: add workstation lanes to supervisor board

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2025-10-10T12:00:00Z — Agent: gpt-5-codex
+
+- **Summary:** Enriched the supervisor dashboard API with workstation metadata, reworked the Kanban board to build dynamic work-center lanes with fallbacks, and added contract/unit tests covering the new dashboard payload and kanban grouping.
+- **Reasoning:** Provide supervisors with workstation-aware visibility so the board layout matches active centers while ensuring future regressions are caught automatically.
+- **Hats:** api-contract, role-ui, qa-gate.
+
 ## 2025-10-09T14:22:24Z — Agent: gpt-5-codex
 
 - **Summary:** Rebuilt the operator console UI to consume theme-aware tokens, shared form primitives, and semantic status badges so every panel, table, and action control honors dark mode. Refreshed the product model/trim selector to lean on the shared Select/Input components, ensuring supervisor planning forms inherit the same adaptive styling.

--- a/src/app/api/__tests__/supervisor.dashboard.test.ts
+++ b/src/app/api/__tests__/supervisor.dashboard.test.ts
@@ -1,0 +1,190 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { WOStatus, WOPriority } from "@prisma/client";
+
+const {
+  findManyMock,
+  countMock,
+  stageLogFindManyMock,
+  getUserFromRequestMock,
+} = vi.hoisted(() => ({
+  findManyMock: vi.fn(),
+  countMock: vi.fn(),
+  stageLogFindManyMock: vi.fn(),
+  getUserFromRequestMock: vi.fn(),
+}));
+
+vi.mock("@/server/db/client", () => ({
+  prisma: {
+    workOrder: {
+      findMany: findManyMock,
+      count: countMock,
+    },
+    wOStageLog: {
+      findMany: stageLogFindManyMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getUserFromRequest: getUserFromRequestMock,
+}));
+
+import { GET } from "../supervisor/dashboard/route";
+
+function buildRequest(url: string) {
+  return new NextRequest(url);
+}
+
+describe("GET /api/supervisor/dashboard", () => {
+  beforeEach(() => {
+    findManyMock.mockReset();
+    countMock.mockReset();
+    stageLogFindManyMock.mockReset();
+    getUserFromRequestMock.mockReset();
+  });
+
+  it("returns stage metadata and an ordered work-center list", async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: "user-1",
+      role: "SUPERVISOR",
+    });
+
+    const createdAt = new Date("2025-02-01T00:00:00Z");
+
+    findManyMock.mockResolvedValue([
+      {
+        id: "wo-1",
+        number: "WO-1",
+        hullId: "H1",
+        productSku: "SKU-1",
+        status: WOStatus.IN_PROGRESS,
+        priority: WOPriority.HIGH,
+        qty: 2,
+        plannedStartDate: createdAt,
+        plannedFinishDate: new Date("2025-02-05T00:00:00Z"),
+        currentStageIndex: 1,
+        createdAt,
+        routingVersion: {
+          stages: [
+            {
+              id: "stage-1",
+              code: "CUT",
+              name: "Cutting",
+              sequence: 1,
+              enabled: true,
+              workCenter: {
+                id: "wc-1",
+                name: "Cutting Center",
+                isActive: true,
+                department: { id: "dept-1", name: "Cutting" },
+              },
+            },
+            {
+              id: "stage-2",
+              code: "LAM",
+              name: "Lamination",
+              sequence: 2,
+              enabled: true,
+              workCenter: {
+                id: "wc-2",
+                name: "Lamination Center",
+                isActive: true,
+                department: { id: "dept-2", name: "Lamination" },
+              },
+            },
+          ],
+        },
+        woStageLogs: [
+          {
+            event: "START",
+            createdAt,
+            user: { email: "operator@example.com" },
+            station: { code: "CUT-1" },
+          },
+        ],
+        _count: { notes: 1, attachments: 0 },
+      },
+      {
+        id: "wo-2",
+        number: "WO-2",
+        hullId: "H2",
+        productSku: "SKU-2",
+        status: WOStatus.RELEASED,
+        priority: WOPriority.NORMAL,
+        qty: 1,
+        plannedStartDate: null,
+        plannedFinishDate: null,
+        currentStageIndex: 0,
+        createdAt,
+        routingVersion: {
+          stages: [
+            {
+              id: "stage-3",
+              code: "QA",
+              name: "Quality Assurance",
+              sequence: 3,
+              enabled: true,
+              workCenter: {
+                id: "wc-3",
+                name: "QA Bay",
+                isActive: true,
+                department: { id: "dept-3", name: "QA" },
+              },
+            },
+          ],
+        },
+        woStageLogs: [],
+        _count: { notes: 0, attachments: 1 },
+      },
+    ]);
+
+    countMock.mockResolvedValue(0);
+    stageLogFindManyMock.mockResolvedValue([]);
+
+    const response = await GET(
+      buildRequest("https://example.com/api/supervisor/dashboard"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+
+    const [firstWorkOrder] = payload.data.wipData;
+    expect(firstWorkOrder).toMatchObject({
+      id: "wo-1",
+      priority: WOPriority.HIGH,
+      plannedStartDate: createdAt.toISOString(),
+      currentStage: {
+        id: "stage-2",
+        sequence: 2,
+        workCenter: { id: "wc-2", name: "Lamination Center" },
+        department: { id: "dept-2", name: "Lamination" },
+      },
+    });
+
+    expect(payload.data.workCenters).toEqual([
+      {
+        id: "wc-1",
+        name: "Cutting Center",
+        departmentId: "dept-1",
+        departmentName: "Cutting",
+        sequence: 1,
+      },
+      {
+        id: "wc-2",
+        name: "Lamination Center",
+        departmentId: "dept-2",
+        departmentName: "Lamination",
+        sequence: 2,
+      },
+      {
+        id: "wc-3",
+        name: "QA Bay",
+        departmentId: "dept-3",
+        departmentName: "QA",
+        sequence: 3,
+      },
+    ]);
+  });
+});

--- a/src/app/supervisor/__tests__/kanban-columns.test.ts
+++ b/src/app/supervisor/__tests__/kanban-columns.test.ts
@@ -99,4 +99,47 @@ describe("buildKanbanColumns", () => {
       "wo-complete",
     ]);
   });
+
+  it("places in-progress work orders with unknown work centers into the unassigned column", () => {
+    const workCenters: KanbanWorkCenter[] = [
+      {
+        id: "wc-known",
+        name: "Known Station",
+        departmentId: "dept-1",
+        departmentName: "Department",
+        sequence: 1,
+      },
+    ];
+
+    const workOrders: SupervisorWorkOrder[] = [
+      {
+        hullId: "HULL",
+        productSku: "SKU",
+        qty: 1,
+        currentStageIndex: 0,
+        specSnapshot: {},
+        createdAt: new Date("2025-02-01T00:00:00Z").toISOString(),
+        plannedStartDate: null,
+        plannedFinishDate: null,
+        priority: "NORMAL",
+        _count: { notes: 0, attachments: 0 },
+        currentWorkCenterId: "wc-missing",
+        currentWorkCenterName: "Missing Station",
+        currentDepartmentName: "Missing Department",
+        currentStage: undefined,
+        id: "wo-missing-station",
+        number: "WO-MISSING",
+        status: "IN_PROGRESS",
+      },
+    ];
+
+    const columns = buildKanbanColumns(workOrders, workCenters);
+
+    const unassignedColumn = columns.find(
+      (column) => column.key === "unassigned",
+    );
+    expect(unassignedColumn?.workOrders.map((wo) => wo.id)).toEqual([
+      "wo-missing-station",
+    ]);
+  });
 });

--- a/src/app/supervisor/__tests__/kanban-columns.test.ts
+++ b/src/app/supervisor/__tests__/kanban-columns.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildKanbanColumns,
+  type KanbanWorkCenter,
+  type SupervisorWorkOrder,
+} from "../page";
+
+describe("buildKanbanColumns", () => {
+  it("groups in-progress work orders under their workstation column", () => {
+    const workCenters: KanbanWorkCenter[] = [
+      {
+        id: "wc-1",
+        name: "Cutting Center",
+        departmentId: "dept-1",
+        departmentName: "Cutting",
+        sequence: 1,
+      },
+      {
+        id: "wc-2",
+        name: "Lamination",
+        departmentId: "dept-2",
+        departmentName: "Lamination",
+        sequence: 2,
+      },
+    ];
+
+    const baseWorkOrder: Omit<SupervisorWorkOrder, "id" | "number" | "status"> =
+      {
+        hullId: "HULL",
+        productSku: "SKU",
+        qty: 1,
+        currentStageIndex: 0,
+        specSnapshot: {},
+        createdAt: new Date("2025-02-01T00:00:00Z").toISOString(),
+        plannedStartDate: null,
+        plannedFinishDate: null,
+        priority: "NORMAL",
+        _count: { notes: 0, attachments: 0 },
+        currentWorkCenterId: null,
+        currentWorkCenterName: null,
+        currentDepartmentName: null,
+        currentStage: undefined,
+      };
+
+    const workOrders: SupervisorWorkOrder[] = [
+      {
+        ...baseWorkOrder,
+        id: "wo-backlog",
+        number: "WO-BACKLOG",
+        status: "RELEASED",
+      },
+      {
+        ...baseWorkOrder,
+        id: "wo-in-progress",
+        number: "WO-INPROG",
+        status: "IN_PROGRESS",
+        currentWorkCenterId: "wc-2",
+        currentWorkCenterName: "Lamination",
+        currentDepartmentName: "Lamination",
+      },
+      {
+        ...baseWorkOrder,
+        id: "wo-unassigned",
+        number: "WO-UNASSIGNED",
+        status: "IN_PROGRESS",
+      },
+      {
+        ...baseWorkOrder,
+        id: "wo-complete",
+        number: "WO-COMPLETE",
+        status: "COMPLETED",
+      },
+    ];
+
+    const columns = buildKanbanColumns(workOrders, workCenters);
+
+    const backlogColumn = columns.find((column) => column.key === "backlog");
+    expect(backlogColumn?.workOrders.map((wo) => wo.id)).toEqual([
+      "wo-backlog",
+    ]);
+
+    const laminationColumn = columns.find(
+      (column) => column.key === "work-center-wc-2",
+    );
+    expect(laminationColumn?.workOrders.map((wo) => wo.id)).toEqual([
+      "wo-in-progress",
+    ]);
+
+    const unassignedColumn = columns.find(
+      (column) => column.key === "unassigned",
+    );
+    expect(unassignedColumn?.workOrders.map((wo) => wo.id)).toEqual([
+      "wo-unassigned",
+    ]);
+
+    const completedColumn = columns.at(-1);
+    expect(completedColumn?.key).toBe("completed");
+    expect(completedColumn?.workOrders.map((wo) => wo.id)).toEqual([
+      "wo-complete",
+    ]);
+  });
+});

--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -147,10 +147,15 @@ export function buildKanbanColumns(
   );
 
   const workCenterBuckets = new Map<string, WorkOrder[]>();
+  const knownWorkCenterIds = new Set(workCenters.map((center) => center.id));
   const unassigned: WorkOrder[] = [];
 
   for (const wo of inProgressOrders) {
     if (wo.currentWorkCenterId) {
+      if (!knownWorkCenterIds.has(wo.currentWorkCenterId)) {
+        unassigned.push(wo);
+        continue;
+      }
       if (!workCenterBuckets.has(wo.currentWorkCenterId)) {
         workCenterBuckets.set(wo.currentWorkCenterId, []);
       }


### PR DESCRIPTION
## Summary
- enrich the supervisor dashboard payload with detailed current-stage metadata and an ordered list of active work centers
- update the supervisor kanban view to build dynamic workstation lanes, display fallbacks for missing stage data, and persist the new metadata client-side
- add contract and unit coverage for the dashboard response and the kanban column builder to guard the new behaviour

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68efa33c577883208643aec382bcded2