### PR TITLE
Fix supervisor work center display

### DIFF
--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -1870,7 +1870,13 @@ export default function SupervisorView() {
                               )}
                             </td>
                             <td style={{ padding: "0.75rem" }}>
-                              {wo.currentStage?.workCenter || "-"}
+                              {wo.currentStage?.workCenter?.name
+                                ? `${wo.currentStage.workCenter.name}${
+                                    wo.currentStage.department?.name
+                                      ? ` (${wo.currentStage.department.name})`
+                                      : ""
+                                  }`
+                                : "-"}
                             </td>
                             <td style={{ padding: "0.75rem" }}>
                               <div style={{ display: "flex", gap: "0.25rem" }}>


### PR DESCRIPTION
## Summary
- render the supervisor work center table cell with the work center name and optional department string so objects are not rendered directly

## Testing
- npm run dev
- curl -I http://localhost:5000/supervisor

------
https://chatgpt.com/codex/tasks/task_e_68efba63d5c0832086af3982e640aeda