### PR TITLE
Improve supervisor kanban scrolling and theme toggle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2025-10-15T15:40:02Z — Agent: gpt-5-codex
+
+- **Summary:** Refined the supervisor Kanban into an accessible horizontal gallery with snap scrolling, stable gutters, and responsive column sizing while anchoring the theme toggle to the safe-area inset on touch devices.
+- **Reasoning:** Ensure supervisors can browse every lane on mobile and desktop without layout overflow and keep the dark mode control unobtrusive yet reachable across devices with dynamic safe-area spacing.
+- **Hats:** role-ui, qa-gate, docs.
+
 ## 2025-10-10T12:00:00Z — Agent: gpt-5-codex
 
 - **Summary:** Enriched the supervisor dashboard API with workstation metadata, reworked the Kanban board to build dynamic work-center lanes with fallbacks, and added contract/unit tests covering the new dashboard payload and kanban grouping.

--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -1068,7 +1068,7 @@ export default function SupervisorView() {
               scrollPaddingInline: "0.25rem",
               alignItems: "stretch",
               scrollbarGutter: "stable both-edges",
-              touchAction: "pan-x",
+              touchAction: "pan-x pan-y",
             }}
           >
             {columns.map((column) => {

--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -1051,65 +1051,81 @@ export default function SupervisorView() {
 
         <div
           style={{
-            display: "grid",
-            gridTemplateColumns: `repeat(${Math.max(
-              columns.length,
-              1,
-            )}, minmax(220px, 1fr))`,
-            gap: "1rem",
+            position: "relative",
           }}
         >
-          {columns.map((column) => {
-            const columnWOs = column.workOrders;
+          <div
+            role="list"
+            aria-label="Active work orders grouped by stage"
+            style={{
+              display: "flex",
+              gap: "1rem",
+              overflowX: "auto",
+              padding: "0 0.25rem 0.75rem",
+              margin: "0 -0.25rem",
+              WebkitOverflowScrolling: "touch",
+              scrollSnapType: "x mandatory",
+              scrollPaddingInline: "0.25rem",
+              alignItems: "stretch",
+              scrollbarGutter: "stable both-edges",
+              touchAction: "pan-x",
+            }}
+          >
+            {columns.map((column) => {
+              const columnWOs = column.workOrders;
 
-            return (
-              <div
-                key={column.key}
-                style={{
-                  backgroundColor: "var(--surface)",
-                  borderRadius: "8px",
-                  padding: "1rem",
-                  boxShadow: "var(--shadow-card)",
-                  minHeight: "400px",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "0.75rem",
-                }}
-              >
-                <div>
-                  <h3
-                    style={{
-                      margin: "0 0 0.25rem 0",
-                      fontSize: "1.1rem",
-                      fontWeight: "600",
-                    }}
-                  >
-                    {column.label} ({columnWOs.length})
-                  </h3>
-                  {column.description && (
-                    <p
+              return (
+                <div
+                  key={column.key}
+                  role="listitem"
+                  style={{
+                    backgroundColor: "var(--surface)",
+                    borderRadius: "8px",
+                    padding: "1rem",
+                    boxShadow: "var(--shadow-card)",
+                    minHeight: "400px",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.75rem",
+                    flex: "0 0 clamp(260px, 60vw, 340px)",
+                    scrollSnapAlign: "start",
+                    scrollMarginInline: "0.25rem",
+                  }}
+                >
+                  <div>
+                    <h3
                       style={{
-                        margin: 0,
-                        fontSize: "0.8rem",
+                        margin: "0 0 0.25rem 0",
+                        fontSize: "1.1rem",
+                        fontWeight: "600",
+                      }}
+                    >
+                      {column.label} ({columnWOs.length})
+                    </h3>
+                    {column.description && (
+                      <p
+                        style={{
+                          margin: 0,
+                          fontSize: "0.8rem",
+                          color: "var(--muted)",
+                        }}
+                      >
+                        {column.description}
+                      </p>
+                    )}
+                  </div>
+
+                  {columnWOs.length === 0 ? (
+                    <div
+                      style={{
+                        fontSize: "0.85rem",
                         color: "var(--muted)",
                       }}
                     >
-                      {column.description}
-                    </p>
-                  )}
-                </div>
-
-                {columnWOs.length === 0 ? (
-                  <div
-                    style={{
-                      fontSize: "0.85rem",
-                      color: "var(--muted)",
-                    }}
-                  >
-                    No work orders
-                  </div>
-                ) : (
-                  columnWOs.map((wo) => {
+                      No work orders
+                    </div>
+                  ) : (
+                    columnWOs.map((wo) => {
                     const priorityColors: Record<
                       string,
                       { bg: string; text: string }
@@ -1302,6 +1318,7 @@ export default function SupervisorView() {
           })}
         </div>
       </div>
+    </div>
     );
   };
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -16,13 +16,17 @@ export function ThemeToggle({ className }: { className?: string }) {
       aria-label={label}
       aria-pressed={isDark}
       className={clsx(
-        "fixed top-4 right-4 z-50 inline-flex items-center justify-center rounded-full border transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        "fixed bottom-4 right-4 z-50 inline-flex items-center justify-center rounded-full border transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 sm:bottom-5 sm:right-5",
         "h-10 w-10 border-slate-200 bg-white/90 text-slate-700 shadow-sm backdrop-blur",
         "hover:border-slate-300 hover:text-slate-900",
         "dark:border-slate-700 dark:bg-slate-800/90 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white",
         "focus-visible:ring-primary-500 focus-visible:ring-offset-slate-100 dark:focus-visible:ring-offset-slate-900",
         className,
       )}
+      style={{
+        insetInlineEnd: "calc(1rem + env(safe-area-inset-right, 0px))",
+        insetBlockEnd: "calc(1rem + env(safe-area-inset-bottom, 0px))",
+      }}
       disabled={!isReady}
     >
       <span className="sr-only">{label}</span>


### PR DESCRIPTION
## Summary
- move the floating theme toggle to the bottom-right corner with safe-area spacing so it stays out of the primary content area
- update the supervisor kanban view to render columns in an accessible horizontally scrollable flex gallery with snap alignment that works on small and large screens

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68efbd080dc08320aeb3d277b2f8e25e