### PR TITLE
Adjust supervisor kanban styling

### DIFF
--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -1023,7 +1023,8 @@ export default function SupervisorView() {
     return (
       <div
         style={{
-          backgroundColor: "var(--surface)",
+          backgroundColor: "var(--surface-muted)",
+          border: "1px solid var(--border)",
           borderRadius: "8px",
           boxShadow: "var(--shadow-card)",
           padding: "1.25rem",
@@ -1080,9 +1081,10 @@ export default function SupervisorView() {
                   role="listitem"
                   style={{
                     backgroundColor: "var(--surface)",
+                    border: "1px solid var(--border)",
                     borderRadius: "8px",
                     padding: "1rem",
-                    boxShadow: "var(--shadow-card)",
+                    boxShadow: "var(--shadow-card-hover)",
                     minHeight: "400px",
                     display: "flex",
                     flexDirection: "column",


### PR DESCRIPTION
## Summary
- update the kanban board wrapper to use the muted surface token and border for better theme alignment
- add borders and stronger elevation on kanban columns to improve separation between lists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efc784b76c832092d97225d9062664