### PR TITLE
Enable supervisor planning edits across active work orders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2025-10-15T16:14:46Z — Agent: gpt-5-codex
+
+- **Summary:** Added an explicit edit workflow for supervisor planning details, including an unlock button and cancel/save controls that preserve the existing read-only view. Enabled editing across active statuses and updated the API to validate changes, record version snapshots, and allow supervisors to adjust planning dates without future-date restrictions.
+- **Reasoning:** Supervisors need to adjust planning data on in-flight work orders while maintaining the audit trail and snapshot history so downstream teams see accurate priorities and schedule expectations.
+- **Hats:** role-ui, api-contract, docs.
+
 ## 2025-10-15T15:40:02Z — Agent: gpt-5-codex
 
 - **Summary:** Refined the supervisor Kanban into an accessible horizontal gallery with snap scrolling, stable gutters, and responsive column sizing while anchoring the theme toggle to the safe-area inset on touch devices.

--- a/src/app/api/work-orders/[id]/route.ts
+++ b/src/app/api/work-orders/[id]/route.ts
@@ -294,6 +294,46 @@ export async function PATCH(
     const updateData: Record<string, any> = {};
     const changes: string[] = [];
 
+    const planningStatuses = ["PLANNED", "CANCELLED"] as const;
+    const isPlanningPhase = planningStatuses.includes(currentWorkOrder.status);
+
+    if (
+      data.hullId &&
+      data.hullId !== currentWorkOrder.hullId &&
+      !isPlanningPhase
+    ) {
+      return NextResponse.json(
+        {
+          error: "Hull cannot be changed once the work order is active",
+        },
+        { status: 400 },
+      );
+    }
+    if (
+      data.productSku &&
+      data.productSku !== currentWorkOrder.productSku &&
+      !isPlanningPhase
+    ) {
+      return NextResponse.json(
+        {
+          error: "Product SKU cannot be changed once the work order is active",
+        },
+        { status: 400 },
+      );
+    }
+    if (
+      data.qty !== undefined &&
+      data.qty !== currentWorkOrder.qty &&
+      !isPlanningPhase
+    ) {
+      return NextResponse.json(
+        {
+          error: "Quantity cannot be changed once the work order is active",
+        },
+        { status: 400 },
+      );
+    }
+
     if (data.hullId && data.hullId !== currentWorkOrder.hullId) {
       updateData.hullId = data.hullId;
       changes.push(

--- a/src/app/api/work-orders/[id]/route.ts
+++ b/src/app/api/work-orders/[id]/route.ts
@@ -3,9 +3,7 @@ import { prisma } from "@/server/db/client";
 import { getUserFromRequest } from "../../../../lib/auth";
 import { Role } from "@prisma/client";
 import { z } from "zod";
-
-const WORK_ORDER_SNAPSHOT_SCHEMA_HASH =
-  "sha256:9432e0852b36e8977fa28b81779c5366c58005fab189cd16ebe38bb644145d9d";
+import { WORK_ORDER_SNAPSHOT_SCHEMA_HASH } from "@/server/work-orders/snapshot-metadata";
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/work-orders/[id]/route.ts
+++ b/src/app/api/work-orders/[id]/route.ts
@@ -4,6 +4,9 @@ import { getUserFromRequest } from "../../../../lib/auth";
 import { Role } from "@prisma/client";
 import { z } from "zod";
 
+const WORK_ORDER_SNAPSHOT_SCHEMA_HASH =
+  "sha256:9432e0852b36e8977fa28b81779c5366c58005fab189cd16ebe38bb644145d9d";
+
 export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } },
@@ -397,6 +400,8 @@ export async function PATCH(
 
         const newVersionNumber = (latestVersion?.versionNumber || 0) + 1;
         const snapshot = {
+          schema_hash: WORK_ORDER_SNAPSHOT_SCHEMA_HASH,
+          versionNumber: newVersionNumber,
           number: updated.number,
           hullId: updated.hullId,
           productSku: updated.productSku,

--- a/src/app/api/work-orders/[id]/route.ts
+++ b/src/app/api/work-orders/[id]/route.ts
@@ -1,20 +1,20 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/server/db/client'
-import { getUserFromRequest } from '../../../../lib/auth'
-import { Role } from '@prisma/client'
-import { z } from 'zod'
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/server/db/client";
+import { getUserFromRequest } from "../../../../lib/auth";
+import { Role } from "@prisma/client";
+import { z } from "zod";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: { id: string } },
 ) {
   try {
-    const user = getUserFromRequest(request)
+    const user = getUserFromRequest(request);
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const workOrderId = params.id
+    const workOrderId = params.id;
 
     // Get work order with full details
     const workOrder = await prisma.workOrder.findUnique({
@@ -23,91 +23,107 @@ export async function GET(
         routingVersion: {
           include: {
             stages: {
-              orderBy: { sequence: 'asc' },
+              orderBy: { sequence: "asc" },
               include: {
                 workCenter: {
                   include: {
                     department: true,
                     stations: {
-                      where: { isActive: true }
-                    }
-                  }
+                      where: { isActive: true },
+                    },
+                  },
                 },
                 workInstructionVersions: {
                   where: { isActive: true },
-                  orderBy: { version: 'desc' },
-                  take: 1
-                }
-              }
-            }
-          }
+                  orderBy: { version: "desc" },
+                  take: 1,
+                },
+              },
+            },
+          },
         },
         woStageLogs: {
-          orderBy: { createdAt: 'desc' },
+          orderBy: { createdAt: "desc" },
           include: {
             routingStage: {
               include: {
-                workCenter: true
-              }
+                workCenter: true,
+              },
             },
             station: true,
             user: {
               select: {
                 id: true,
                 email: true,
-                role: true
-              }
-            }
-          }
-        }
-      }
-    })
+                role: true,
+              },
+            },
+          },
+        },
+      },
+    });
 
     if (!workOrder) {
-      return NextResponse.json({ error: 'Work order not found' }, { status: 404 })
+      return NextResponse.json(
+        { error: "Work order not found" },
+        { status: 404 },
+      );
     }
 
     // Check department scoping for operators only (admin and supervisor have full access)
     if (user.role === Role.OPERATOR && user.departmentId) {
-      const enabledStages = workOrder.routingVersion.stages.filter(s => s.enabled)
-      const currentStage = enabledStages[workOrder.currentStageIndex]
-      
-      if (currentStage && currentStage.workCenter.department.id !== user.departmentId) {
-        return NextResponse.json({ error: 'Work order not in your department' }, { status: 403 })
+      const enabledStages = workOrder.routingVersion.stages.filter(
+        (s) => s.enabled,
+      );
+      const currentStage = enabledStages[workOrder.currentStageIndex];
+
+      if (
+        currentStage &&
+        currentStage.workCenter.department.id !== user.departmentId
+      ) {
+        return NextResponse.json(
+          { error: "Work order not in your department" },
+          { status: 403 },
+        );
       }
     }
 
     // Calculate stage timeline
-    const stageTimeline = workOrder.woStageLogs.reduce((timeline, log) => {
-      const stageId = log.routingStage.id
-      if (!timeline[stageId]) {
-        timeline[stageId] = {
-          stageId,
-          stageName: log.routingStage.name,
-          stageCode: log.routingStage.code,
-          workCenter: log.routingStage.workCenter.name,
-          events: []
+    const stageTimeline = workOrder.woStageLogs.reduce(
+      (timeline, log) => {
+        const stageId = log.routingStage.id;
+        if (!timeline[stageId]) {
+          timeline[stageId] = {
+            stageId,
+            stageName: log.routingStage.name,
+            stageCode: log.routingStage.code,
+            workCenter: log.routingStage.workCenter.name,
+            events: [],
+          };
         }
-      }
-      
-      timeline[stageId].events.push({
-        id: log.id,
-        event: log.event,
-        createdAt: log.createdAt,
-        station: log.station.name,
-        stationCode: log.station.code,
-        user: log.user.email,
-        goodQty: log.goodQty,
-        scrapQty: log.scrapQty,
-        note: log.note
-      })
-      
-      return timeline
-    }, {} as Record<string, any>)
+
+        timeline[stageId].events.push({
+          id: log.id,
+          event: log.event,
+          createdAt: log.createdAt,
+          station: log.station.name,
+          stationCode: log.station.code,
+          user: log.user.email,
+          goodQty: log.goodQty,
+          scrapQty: log.scrapQty,
+          note: log.note,
+        });
+
+        return timeline;
+      },
+      {} as Record<string, any>,
+    );
 
     // Get enabled stages for progress tracking
-    const enabledStages = workOrder.routingVersion.stages.filter(s => s.enabled)
-    const currentStage = enabledStages[workOrder.currentStageIndex]
+    const enabledStages = workOrder.routingVersion.stages.filter(
+      (s) => s.enabled,
+    );
+    const currentStage = enabledStages[workOrder.currentStageIndex];
 
     return NextResponse.json({
       workOrder: {
@@ -128,41 +144,46 @@ export async function GET(
           model: workOrder.routingVersion.model,
           trim: workOrder.routingVersion.trim,
           version: workOrder.routingVersion.version,
-          status: workOrder.routingVersion.status
+          status: workOrder.routingVersion.status,
         },
-        currentStage: currentStage ? {
-          id: currentStage.id,
-          code: currentStage.code,
-          name: currentStage.name,
-          sequence: currentStage.sequence,
-          workCenter: currentStage.workCenter.name,
-          department: currentStage.workCenter.department.name,
-          standardSeconds: currentStage.standardStageSeconds
-        } : null,
-        enabledStages: enabledStages.map(s => ({
+        currentStage: currentStage
+          ? {
+              id: currentStage.id,
+              code: currentStage.code,
+              name: currentStage.name,
+              sequence: currentStage.sequence,
+              workCenter: currentStage.workCenter.name,
+              department: currentStage.workCenter.department.name,
+              standardSeconds: currentStage.standardStageSeconds,
+            }
+          : null,
+        enabledStages: enabledStages.map((s) => ({
           id: s.id,
           code: s.code,
           name: s.name,
           sequence: s.sequence,
           enabled: s.enabled,
           workCenter: s.workCenter.name,
-          department: s.workCenter.department.name
+          department: s.workCenter.department.name,
         })),
         stageTimeline: Object.values(stageTimeline),
         notes: workOrder.woStageLogs
-          .filter(log => log.note)
-          .map(log => ({
+          .filter((log) => log.note)
+          .map((log) => ({
             note: log.note,
             event: log.event,
             stage: log.routingStage.name,
             user: log.user.email,
-            createdAt: log.createdAt
-          }))
-      }
-    })
+            createdAt: log.createdAt,
+          })),
+      },
+    });
   } catch (error) {
-    console.error('Get work order details error:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    console.error("Get work order details error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
@@ -171,147 +192,269 @@ const updateWorkOrderSchema = z.object({
   hullId: z.string().min(1).optional(),
   productSku: z.string().min(1).optional(),
   qty: z.number().positive().optional(),
-  priority: z.enum(['LOW', 'NORMAL', 'HIGH', 'CRITICAL']).optional(),
+  priority: z.enum(["LOW", "NORMAL", "HIGH", "CRITICAL"]).optional(),
   plannedStartDate: z.string().datetime().optional().nullable(),
   plannedFinishDate: z.string().datetime().optional().nullable(),
-})
+});
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: { id: string } },
 ) {
   try {
-    const user = getUserFromRequest(request)
+    const user = getUserFromRequest(request);
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     // Only supervisors and admins can update work orders
     if (user.role === Role.OPERATOR) {
-      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+      return NextResponse.json(
+        { error: "Insufficient permissions" },
+        { status: 403 },
+      );
     }
 
-    const workOrderId = params.id
-    const body = await request.json()
-    
+    const workOrderId = params.id;
+    const body = await request.json();
+
     // Validate request body
-    const validation = updateWorkOrderSchema.safeParse(body)
+    const validation = updateWorkOrderSchema.safeParse(body);
     if (!validation.success) {
-      return NextResponse.json({
-        error: 'Validation failed',
-        errors: validation.error.flatten().fieldErrors
-      }, { status: 400 })
+      return NextResponse.json(
+        {
+          error: "Validation failed",
+          errors: validation.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
     }
 
-    const data = validation.data
+    const data = validation.data;
 
-    // Date validation
-    if (data.plannedStartDate && data.plannedFinishDate) {
-      const startDate = new Date(data.plannedStartDate)
-      const finishDate = new Date(data.plannedFinishDate)
-      
-      if (startDate >= finishDate) {
-        return NextResponse.json({
-          error: 'Planned start date must be before planned finish date'
-        }, { status: 400 })
-      }
+    const requestedStart =
+      data.plannedStartDate === undefined
+        ? undefined
+        : data.plannedStartDate
+          ? new Date(data.plannedStartDate)
+          : null;
+    const requestedFinish =
+      data.plannedFinishDate === undefined
+        ? undefined
+        : data.plannedFinishDate
+          ? new Date(data.plannedFinishDate)
+          : null;
 
-      // Check if start date is in the future (only for new/changed dates)
-      const now = new Date()
-      if (startDate < now) {
-        return NextResponse.json({
-          error: 'Planned start date must be in the future'
-        }, { status: 400 })
-      }
-    }
-
-    // Get current work order state for audit logging
     const currentWorkOrder = await prisma.workOrder.findUnique({
-      where: { id: workOrderId }
-    })
+      where: { id: workOrderId },
+    });
 
     if (!currentWorkOrder) {
-      return NextResponse.json({ error: 'Work order not found' }, { status: 404 })
+      return NextResponse.json(
+        { error: "Work order not found" },
+        { status: 404 },
+      );
     }
 
-    // Check if work order can be edited (only PLANNED and CANCELLED statuses)
-    if (!['PLANNED', 'CANCELLED'].includes(currentWorkOrder.status)) {
-      return NextResponse.json({
-        error: 'Work order can only be edited in PLANNED or CANCELLED status'
-      }, { status: 400 })
+    const finalStart =
+      requestedStart !== undefined
+        ? requestedStart
+        : currentWorkOrder.plannedStartDate;
+    const finalFinish =
+      requestedFinish !== undefined
+        ? requestedFinish
+        : currentWorkOrder.plannedFinishDate;
+
+    if (finalStart && finalFinish && finalStart >= finalFinish) {
+      return NextResponse.json(
+        {
+          error: "Planned start date must be before planned finish date",
+        },
+        { status: 400 },
+      );
     }
 
-    // Build update object with only changed fields
-    const updateData: any = {}
-    const changes: string[] = []
+    const editableStatuses = [
+      "PLANNED",
+      "RELEASED",
+      "IN_PROGRESS",
+      "HOLD",
+      "CANCELLED",
+    ];
+    if (!editableStatuses.includes(currentWorkOrder.status)) {
+      return NextResponse.json(
+        {
+          error: "Work order can only be edited while active",
+        },
+        { status: 400 },
+      );
+    }
+
+    const updateData: Record<string, any> = {};
+    const changes: string[] = [];
 
     if (data.hullId && data.hullId !== currentWorkOrder.hullId) {
-      updateData.hullId = data.hullId
-      changes.push(`Hull ID changed from ${currentWorkOrder.hullId} to ${data.hullId}`)
-    }
-    
-    if (data.productSku && data.productSku !== currentWorkOrder.productSku) {
-      updateData.productSku = data.productSku
-      changes.push(`Product SKU changed from ${currentWorkOrder.productSku} to ${data.productSku}`)
-    }
-    
-    if (data.qty !== undefined && data.qty !== currentWorkOrder.qty) {
-      updateData.qty = data.qty
-      changes.push(`Quantity changed from ${currentWorkOrder.qty} to ${data.qty}`)
-    }
-    
-    if (data.priority && data.priority !== currentWorkOrder.priority) {
-      updateData.priority = data.priority as any
-      changes.push(`Priority changed from ${currentWorkOrder.priority} to ${data.priority}`)
-    }
-    
-    if (data.plannedStartDate !== undefined) {
-      const newDate = data.plannedStartDate ? new Date(data.plannedStartDate) : null
-      updateData.plannedStartDate = newDate
-      changes.push(`Planned start date ${newDate ? 'set to ' + newDate.toISOString() : 'cleared'}`)
-    }
-    
-    if (data.plannedFinishDate !== undefined) {
-      const newDate = data.plannedFinishDate ? new Date(data.plannedFinishDate) : null
-      updateData.plannedFinishDate = newDate
-      changes.push(`Planned finish date ${newDate ? 'set to ' + newDate.toISOString() : 'cleared'}`)
+      updateData.hullId = data.hullId;
+      changes.push(
+        `Hull ID changed from ${currentWorkOrder.hullId} to ${data.hullId}`,
+      );
     }
 
-    // Update work order with audit log
+    if (data.productSku && data.productSku !== currentWorkOrder.productSku) {
+      updateData.productSku = data.productSku;
+      changes.push(
+        `Product SKU changed from ${currentWorkOrder.productSku} to ${data.productSku}`,
+      );
+    }
+
+    if (data.qty !== undefined && data.qty !== currentWorkOrder.qty) {
+      updateData.qty = data.qty;
+      changes.push(
+        `Quantity changed from ${currentWorkOrder.qty} to ${data.qty}`,
+      );
+    }
+
+    const currentPriority = currentWorkOrder.priority as string | null;
+    if (data.priority && data.priority !== currentPriority) {
+      updateData.priority = data.priority as any;
+      const previousPriority = currentPriority ?? "NORMAL";
+      changes.push(
+        `Priority changed from ${previousPriority} to ${data.priority}`,
+      );
+    }
+
+    if (requestedStart !== undefined) {
+      const currentStartIso = currentWorkOrder.plannedStartDate
+        ? currentWorkOrder.plannedStartDate.toISOString()
+        : null;
+      const newStartIso = requestedStart ? requestedStart.toISOString() : null;
+
+      if (currentStartIso !== newStartIso) {
+        updateData.plannedStartDate = requestedStart;
+        const previousLabel = currentStartIso ?? "not set";
+        const nextLabel = newStartIso ?? "cleared";
+        changes.push(
+          `Planned start date changed from ${previousLabel} to ${nextLabel}`,
+        );
+      }
+    }
+
+    if (requestedFinish !== undefined) {
+      const currentFinishIso = currentWorkOrder.plannedFinishDate
+        ? currentWorkOrder.plannedFinishDate.toISOString()
+        : null;
+      const newFinishIso = requestedFinish
+        ? requestedFinish.toISOString()
+        : null;
+
+      if (currentFinishIso !== newFinishIso) {
+        updateData.plannedFinishDate = requestedFinish;
+        const previousLabel = currentFinishIso ?? "not set";
+        const nextLabel = newFinishIso ?? "cleared";
+        changes.push(
+          `Planned finish date changed from ${previousLabel} to ${nextLabel}`,
+        );
+      }
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({
+        success: true,
+        workOrder: currentWorkOrder,
+        changes: ["No changes detected"],
+      });
+    }
+
     const updatedWorkOrder = await prisma.$transaction(async (tx) => {
-      // Update work order
       const updated = await tx.workOrder.update({
         where: { id: workOrderId },
         data: updateData,
         include: {
-          routingVersion: true
-        }
-      })
+          routingVersion: {
+            include: {
+              stages: true,
+            },
+          },
+        },
+      });
 
-      // Create audit log entries for each change
       if (changes.length > 0) {
         await tx.auditLog.createMany({
-          data: changes.map(change => ({
+          data: changes.map((change) => ({
             actorId: user.id,
-            action: 'UPDATE',
-            modelType: 'WorkOrder',
+            action: "UPDATE",
+            modelType: "WorkOrder",
             modelId: workOrderId,
             changes: { message: change, ...updateData },
-            metadata: { workOrderNumber: updated.number }
-          }))
-        })
+            metadata: { workOrderNumber: updated.number },
+          })),
+        });
+
+        const latestVersion = await tx.workOrderVersion.findFirst({
+          where: { workOrderId },
+          orderBy: { versionNumber: "desc" },
+        });
+
+        const newVersionNumber = (latestVersion?.versionNumber || 0) + 1;
+        const snapshot = {
+          number: updated.number,
+          hullId: updated.hullId,
+          productSku: updated.productSku,
+          qty: updated.qty,
+          status: updated.status,
+          priority: updated.priority,
+          plannedStartDate: updated.plannedStartDate,
+          plannedFinishDate: updated.plannedFinishDate,
+          routingVersionId: updated.routingVersionId,
+          currentStageIndex: updated.currentStageIndex,
+          specSnapshot: updated.specSnapshot,
+          routingVersion: updated.routingVersion
+            ? {
+                model: updated.routingVersion.model,
+                trim: updated.routingVersion.trim,
+                version: updated.routingVersion.version,
+                stages: updated.routingVersion.stages.map((stage) => ({
+                  sequence: stage.sequence,
+                  code: stage.code,
+                  name: stage.name,
+                  enabled: stage.enabled,
+                  workCenterId: stage.workCenterId,
+                  standardStageSeconds: stage.standardStageSeconds,
+                })),
+              }
+            : null,
+        };
+
+        const reasonSuffix = changes.join(" | ");
+        const versionReason =
+          changes.length === 1
+            ? changes[0]
+            : `Planning details updated: ${reasonSuffix}`;
+
+        await tx.workOrderVersion.create({
+          data: {
+            workOrderId,
+            versionNumber: newVersionNumber,
+            snapshotData: snapshot,
+            reason: versionReason.slice(0, 255),
+            createdBy: user.email || user.userId || user.id,
+          },
+        });
       }
 
-      return updated
-    })
+      return updated;
+    });
 
     return NextResponse.json({
       success: true,
       workOrder: updatedWorkOrder,
-      changes: changes.length > 0 ? changes : ['No changes made']
-    })
+      changes,
+    });
   } catch (error) {
-    console.error('Update work order error:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    console.error("Update work order error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/work-orders/[id]/route.ts
+++ b/src/app/api/work-orders/[id]/route.ts
@@ -413,7 +413,9 @@ export async function PATCH(
         include: {
           routingVersion: {
             include: {
-              stages: true,
+              stages: {
+                orderBy: { sequence: "asc" },
+              },
             },
           },
         },
@@ -456,12 +458,14 @@ export async function PATCH(
                 model: updated.routingVersion.model,
                 trim: updated.routingVersion.trim,
                 version: updated.routingVersion.version,
-                stages: updated.routingVersion.stages.map((stage) => ({
-                  sequence: stage.sequence,
-                  code: stage.code,
-                  name: stage.name,
-                  enabled: stage.enabled,
-                  workCenterId: stage.workCenterId,
+                stages: [...updated.routingVersion.stages]
+                  .sort((a, b) => a.sequence - b.sequence)
+                  .map((stage) => ({
+                    sequence: stage.sequence,
+                    code: stage.code,
+                    name: stage.name,
+                    enabled: stage.enabled,
+                    workCenterId: stage.workCenterId,
                   standardStageSeconds: stage.standardStageSeconds,
                 })),
               }

--- a/src/server/work-orders/snapshot-metadata.ts
+++ b/src/server/work-orders/snapshot-metadata.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto";
+
+const WORK_ORDER_SNAPSHOT_FIELDS = [
+  "number",
+  "hullId",
+  "productSku",
+  "qty",
+  "status",
+  "priority",
+  "plannedStartDate",
+  "plannedFinishDate",
+  "routingVersionId",
+  "currentStageIndex",
+  "specSnapshot",
+  "routingVersion",
+] as const;
+
+const WORK_ORDER_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export const WORK_ORDER_SNAPSHOT_SCHEMA_HASH = `sha256:${crypto
+  .createHash("sha256")
+  .update(
+    JSON.stringify({
+      version: WORK_ORDER_SNAPSHOT_SCHEMA_VERSION,
+      fields: WORK_ORDER_SNAPSHOT_FIELDS,
+    }),
+  )
+  .digest("hex")}`;
+
+export type WorkOrderSnapshotSchemaField = (typeof WORK_ORDER_SNAPSHOT_FIELDS)[number];
+
+export const WORK_ORDER_SNAPSHOT_SCHEMA_METADATA = {
+  version: WORK_ORDER_SNAPSHOT_SCHEMA_VERSION,
+  fields: WORK_ORDER_SNAPSHOT_FIELDS,
+  hash: WORK_ORDER_SNAPSHOT_SCHEMA_HASH,
+} as const;


### PR DESCRIPTION
## Summary
- add an edit toggle and cancel/save controls to the supervisor planning details drawer while keeping the read-only summary by default
- relax the work order PATCH handler to cover active statuses, skip no-op updates, and emit descriptive version snapshots for audit history
- record the change in the changelog with the relevant roles touched

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68efc30d0d6c832096c04d4faaa2d762