### PR TITLE
Use heroicons paperclip for supervisor attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/storage": "^7.17.1",
+        "@heroicons/react": "^2.2.0",
         "@prisma/client": "^6.16.2",
         "@tailwindcss/postcss": "^4.1.13",
         "@types/bcryptjs": "^2.4.6",
@@ -1019,6 +1020,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@isaacs/fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@google-cloud/storage": "^7.17.1",
+    "@heroicons/react": "^2.2.0",
     "@prisma/client": "^6.16.2",
     "@tailwindcss/postcss": "^4.1.13",
     "@types/bcryptjs": "^2.4.6",
@@ -44,18 +45,12 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
-    "@vitejs/plugin-react": "^5.0.4",
-    "jsdom": "^27.0.0",
-    "vitest": "^2.1.8"
-  },
-  "engines": {
-    "node": ">=20"
-  },
-  "devDependencies": {
-    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^5.0.4",
     "jsdom": "^27.0.0",
     "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -10,6 +10,7 @@ import { DataCard, DataGrid } from "../../components/ui/DataCard";
 import { StatusCard, StatusGrid } from "../../components/ui/StatusCard";
 import { Button } from "../../components/ui/Button";
 import { Select } from "../../components/ui/Select";
+import { PaperClipIcon } from "@heroicons/react/24/solid";
 
 type WorkOrder = {
   id: string;
@@ -1206,9 +1207,36 @@ export default function SupervisorView() {
                                     padding: "0.125rem 0.25rem",
                                     borderRadius: "10px",
                                     fontWeight: "500",
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    gap: "0.25rem",
+                                    position: "relative",
                                   }}
                                 >
-                                  📎 {wo._count.attachments}
+                                  <span
+                                    style={{
+                                      border: 0,
+                                      clip: "rect(0, 0, 0, 0)",
+                                      height: "1px",
+                                      margin: "-1px",
+                                      overflow: "hidden",
+                                      padding: 0,
+                                      position: "absolute",
+                                      width: "1px",
+                                      whiteSpace: "nowrap",
+                                    }}
+                                  >
+                                    {`${wo._count.attachments} attachment${
+                                      wo._count.attachments === 1 ? "" : "s"
+                                    }`}
+                                  </span>
+                                  <PaperClipIcon
+                                    aria-hidden="true"
+                                    style={{ height: "0.75rem", width: "0.75rem" }}
+                                  />
+                                  <span aria-hidden="true">
+                                    {wo._count.attachments}
+                                  </span>
                                 </span>
                               )}
                               {wo._count && wo._count.notes > 0 && (
@@ -1840,10 +1868,36 @@ export default function SupervisorView() {
                                     padding: "0.25rem 0.5rem",
                                     borderRadius: "12px",
                                     fontWeight: "500",
-                                    display: "inline-block",
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    gap: "0.25rem",
+                                    position: "relative",
                                   }}
                                 >
-                                  📎 {wo._count.attachments}
+                                  <span
+                                    style={{
+                                      border: 0,
+                                      clip: "rect(0, 0, 0, 0)",
+                                      height: "1px",
+                                      margin: "-1px",
+                                      overflow: "hidden",
+                                      padding: 0,
+                                      position: "absolute",
+                                      width: "1px",
+                                      whiteSpace: "nowrap",
+                                    }}
+                                  >
+                                    {`${wo._count.attachments} attachment${
+                                      wo._count.attachments === 1 ? "" : "s"
+                                    }`}
+                                  </span>
+                                  <PaperClipIcon
+                                    aria-hidden="true"
+                                    style={{ height: "0.75rem", width: "0.75rem" }}
+                                  />
+                                  <span aria-hidden="true">
+                                    {wo._count.attachments}
+                                  </span>
                                 </span>
                               ) : (
                                 <span


### PR DESCRIPTION
## Summary
- add the `@heroicons/react` dependency so the supervisor dashboard can use the PaperClip icon
- replace the attachment badges in the supervisor kanban and table views with the PaperClip icon and hidden text for accessibility

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f0064b4c6483208c25bd0a821b9aa8