### PR TITLE
Add dev-only login shortcuts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2025-10-16T13:55:39Z — Agent: gpt-5-codex
+
+- **Summary:** Hid the manual credential form in development, added quick-launch demo account buttons that share the login fetch helper, and kept the production form unchanged for manual sign-in flows.
+- **Reasoning:** Streamline local testing by allowing one-click role switching without disrupting the production login behavior or its error handling.
+- **Hats:** role-ui, qa-gate.
+
 ## 2025-10-15T16:14:46Z — Agent: gpt-5-codex
 
 - **Summary:** Added an explicit edit workflow for supervisor planning details, including an unlock button and cancel/save controls that preserve the existing read-only view. Enabled editing across active statuses and updated the API to validate changes, record version snapshots, and allow supervisors to adjust planning dates without future-date restrictions.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,48 +1,88 @@
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { Input, Button } from '../../components/ui'
+import { type FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input, Button } from "../../components/ui";
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
-  const router = useRouter()
+  const devMode = process.env.NODE_ENV === "development";
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [quickLoginRole, setQuickLoginRole] = useState<string | null>(null);
+  const router = useRouter();
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError('')
-    setLoading(true)
+  const handleLoginRequest = async ({
+    email,
+    password,
+  }: {
+    email: string;
+    password: string;
+  }) => {
+    setError("");
 
     try {
-      const response = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ email, password })
-      })
+      const response = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, password }),
+      });
 
-      const data = await response.json()
+      const data = await response.json();
 
       if (data.ok) {
-        router.push(data.redirectTo)
-      } else {
-        setError(data.error || 'Login failed')
+        router.push(data.redirectTo);
+        return true;
       }
+
+      setError(data.error || "Login failed");
+      return false;
     } catch (err) {
-      setError('Network error. Please try again.')
-    } finally {
-      setLoading(false)
+      setError("Network error. Please try again.");
+      return false;
     }
-  }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      await handleLoginRequest({ email, password });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleQuickLogin = async ({
+    email,
+    password,
+    role,
+  }: {
+    email: string;
+    password: string;
+    role: string;
+  }) => {
+    setQuickLoginRole(role);
+
+    try {
+      await handleLoginRequest({ email, password });
+    } finally {
+      setQuickLoginRole(null);
+    }
+  };
 
   const testAccounts = [
-    { role: 'Operator', email: 'operator@cri.local', password: 'Operator123!' },
-    { role: 'Supervisor', email: 'supervisor@cri.local', password: 'Supervisor123!' },
-    { role: 'Admin', email: 'admin@cri.local', password: 'Admin123!' }
-  ]
+    { role: "Operator", email: "operator@cri.local", password: "Operator123!" },
+    {
+      role: "Supervisor",
+      email: "supervisor@cri.local",
+      password: "Supervisor123!",
+    },
+    { role: "Admin", email: "admin@cri.local", password: "Admin123!" },
+  ];
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4">
@@ -56,64 +96,109 @@ export default function LoginPage() {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <Input
-            type="email"
-            label="Email Address"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="your.email@company.com"
-            isRequired
-            disabled={loading}
-            variant={error ? 'error' : 'default'}
-          />
-
-          <Input
-            type="password"
-            label="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Enter your password"
-            isRequired
-            disabled={loading}
-            variant={error ? 'error' : 'default'}
-          />
-
-          {error && (
-            <div className="p-3 text-sm text-danger-800 bg-danger-50 border border-danger-200 rounded-md flex items-center">
-              <svg className="w-4 h-4 mr-2 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-              </svg>
-              {error}
-            </div>
-          )}
-
-          <Button
-            type="submit"
-            variant="primary"
-            fullWidth
-            loading={loading}
-            disabled={loading || !email.trim() || !password.trim()}
-          >
-            {loading ? 'Signing in...' : 'Sign In'}
-          </Button>
-        </form>
-
-        <div className="mt-8 p-4 bg-slate-50 rounded-md border border-slate-200">
-          <h3 className="text-sm font-semibold text-slate-700 mb-3">
-            Demo Accounts
-          </h3>
-          <div className="space-y-2">
-            {testAccounts.map((account, index) => (
-              <div key={index} className="text-xs font-mono text-slate-600 p-2 bg-white rounded border">
-                <div className="font-medium text-slate-800 mb-1">{account.role}</div>
-                <div className="text-slate-600">{account.email}</div>
-                <div className="text-slate-500">{account.password}</div>
+        {devMode ? (
+          <div className="space-y-6">
+            {error && (
+              <div className="p-3 text-sm text-danger-800 bg-danger-50 border border-danger-200 rounded-md flex items-center">
+                <svg
+                  className="w-4 h-4 mr-2 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                {error}
               </div>
-            ))}
+            )}
+
+            <div className="p-4 bg-slate-50 rounded-md border border-slate-200">
+              <h3 className="text-sm font-semibold text-slate-700 mb-3">
+                Demo Accounts
+              </h3>
+              <div className="space-y-2">
+                {testAccounts.map((account) => (
+                  <Button
+                    key={account.role}
+                    type="button"
+                    variant="secondary"
+                    fullWidth
+                    loading={quickLoginRole === account.role}
+                    disabled={
+                      !!quickLoginRole && quickLoginRole !== account.role
+                    }
+                    onClick={() =>
+                      handleQuickLogin({
+                        email: account.email,
+                        password: account.password,
+                        role: account.role,
+                      })
+                    }
+                  >
+                    {quickLoginRole === account.role
+                      ? `Signing in as ${account.role}...`
+                      : account.role}
+                  </Button>
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <Input
+              type="email"
+              label="Email Address"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your.email@company.com"
+              isRequired
+              disabled={loading}
+              variant={error ? "error" : "default"}
+            />
+
+            <Input
+              type="password"
+              label="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter your password"
+              isRequired
+              disabled={loading}
+              variant={error ? "error" : "default"}
+            />
+
+            {error && (
+              <div className="p-3 text-sm text-danger-800 bg-danger-50 border border-danger-200 rounded-md flex items-center">
+                <svg
+                  className="w-4 h-4 mr-2 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                {error}
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              variant="primary"
+              fullWidth
+              loading={loading}
+              disabled={loading || !email.trim() || !password.trim()}
+            >
+              {loading ? "Signing in..." : "Sign In"}
+            </Button>
+          </form>
+        )}
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- hide the manual credential form when running in development
- centralize the login fetch request and reuse it for quick demo account buttons
- keep the production form intact while enabling dev-only role launchers

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f0f8f0d3f08320a47910da8b7b29bb