### PR TITLE
Add supervisor modal default window helper

### DIFF
--- a/docs/ActionItems.md
+++ b/docs/ActionItems.md
@@ -160,6 +160,16 @@ This document tracks outstanding tasks, improvements, and technical debt for the
   - **Estimated effort**: 45 minutes
   - **Agent role**: Docs & Runbooks
 
+### Developer Experience
+
+- [ ] **Provide default env vars for local dev API flows**
+  - Local QA attempts fail with 500 errors because `DATABASE_URL`, `JWT_SECRET`, and `STORAGE_BUCKET_ID` are undefined during `next dev`
+  - Document setup or supply `.env.example` values that allow non-persistent QA
+  - Consider adding mock/stub mode for modal verification without Postgres
+  - **Estimated effort**: 45 minutes
+  - **Agent role**: Docs & Runbooks
+  - **Discovered**: 2025-10-23 while QAing supervisor modal defaults
+
 ### Error Handling & Observability
 
 - [ ] **Centralize API error handling**

--- a/src/app/supervisor/page.tsx
+++ b/src/app/supervisor/page.tsx
@@ -1,184 +1,194 @@
-"use client";
+'use client'
 
-import { useState, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
-import NotesTimeline from "../../components/NotesTimeline";
-import FileManager from "../../components/FileManager";
-import ModelTrimSelector from "../../components/ModelTrimSelector";
-import { StatsCard, StatsGrid } from "../../components/ui/StatsCard";
-import { DataCard, DataGrid } from "../../components/ui/DataCard";
-import { StatusCard, StatusGrid } from "../../components/ui/StatusCard";
-import { Button } from "../../components/ui/Button";
-import { Select } from "../../components/ui/Select";
-import { PaperClipIcon, ChatBubbleLeftIcon } from "@heroicons/react/24/solid";
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import NotesTimeline from '../../components/NotesTimeline'
+import FileManager from '../../components/FileManager'
+import ModelTrimSelector from '../../components/ModelTrimSelector'
+import { StatsCard, StatsGrid } from '../../components/ui/StatsCard'
+import { DataCard, DataGrid } from '../../components/ui/DataCard'
+import { StatusCard, StatusGrid } from '../../components/ui/StatusCard'
+import { Button } from '../../components/ui/Button'
+import { Select } from '../../components/ui/Select'
+import { PaperClipIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/solid'
 
 type WorkOrder = {
-  id: string;
-  number: string;
-  hullId: string;
-  productSku: string;
-  status:
-    | "PLANNED"
-    | "RELEASED"
-    | "IN_PROGRESS"
-    | "HOLD"
-    | "COMPLETED"
-    | "CLOSED"
-    | "CANCELLED";
-  qty: number;
-  currentStageIndex: number;
-  specSnapshot: any;
-  createdAt: string;
-  plannedStartDate?: string | null;
-  plannedFinishDate?: string | null;
-  priority?: "LOW" | "NORMAL" | "HIGH" | "CRITICAL";
+  id: string
+  number: string
+  hullId: string
+  productSku: string
+  status: 'PLANNED' | 'RELEASED' | 'IN_PROGRESS' | 'HOLD' | 'COMPLETED' | 'CLOSED' | 'CANCELLED'
+  qty: number
+  currentStageIndex: number
+  specSnapshot: any
+  createdAt: string
+  plannedStartDate?: string | null
+  plannedFinishDate?: string | null
+  priority?: 'LOW' | 'NORMAL' | 'HIGH' | 'CRITICAL'
   _count?: {
-    notes: number;
-    attachments: number;
-  };
+    notes: number
+    attachments: number
+  }
   routingVersion?: {
-    id: string;
-    model: string;
-    trim: string | null;
-    version: number;
-    status: string;
-  };
-  currentWorkCenterId?: string | null;
-  currentWorkCenterName?: string | null;
-  currentDepartmentName?: string | null;
+    id: string
+    model: string
+    trim: string | null
+    version: number
+    status: string
+  }
+  currentWorkCenterId?: string | null
+  currentWorkCenterName?: string | null
+  currentDepartmentName?: string | null
   currentStage?: {
-    id: string;
-    code: string;
-    name: string;
-    sequence: number;
+    id: string
+    code: string
+    name: string
+    sequence: number
     workCenter: {
-      id: string;
-      name: string;
-    } | null;
+      id: string
+      name: string
+    } | null
     department: {
-      id: string;
-      name: string;
-    } | null;
-    standardSeconds: number;
-  };
+      id: string
+      name: string
+    } | null
+    standardSeconds: number
+  }
   enabledStages?: Array<{
-    id: string;
-    code: string;
-    name: string;
-    sequence: number;
-    enabled: boolean;
-    workCenter: string;
-    department: string;
-  }>;
+    id: string
+    code: string
+    name: string
+    sequence: number
+    enabled: boolean
+    workCenter: string
+    department: string
+  }>
   stageTimeline?: Array<{
-    stageId: string;
-    stageName: string;
-    stageCode: string;
-    workCenter: string;
+    stageId: string
+    stageName: string
+    stageCode: string
+    workCenter: string
     events: Array<{
-      id: string;
-      event: string;
-      createdAt: string;
-      station: string;
-      stationCode: string;
-      user: string;
-      goodQty: number;
-      scrapQty: number;
-      note: string | null;
-    }>;
-  }>;
+      id: string
+      event: string
+      createdAt: string
+      station: string
+      stationCode: string
+      user: string
+      goodQty: number
+      scrapQty: number
+      note: string | null
+    }>
+  }>
   notes?: Array<{
-    note: string;
-    event: string;
-    stage: string;
-    user: string;
-    createdAt: string;
-  }>;
-};
+    note: string
+    event: string
+    stage: string
+    user: string
+    createdAt: string
+  }>
+}
 
 type RoutingStage = {
-  id?: string;
-  code: string;
-  name: string;
-  sequence: number;
-  enabled: boolean;
-  workCenterId: string;
-  workCenterName?: string;
-  standardStageSeconds: number;
-};
+  id?: string
+  code: string
+  name: string
+  sequence: number
+  enabled: boolean
+  workCenterId: string
+  workCenterName?: string
+  standardStageSeconds: number
+}
 
 type RoutingVersion = {
-  id: string;
-  model: string;
-  trim: string | null;
-  version: number;
-  status: string;
-  stages: RoutingStage[];
-};
+  id: string
+  model: string
+  trim: string | null
+  version: number
+  status: string
+  stages: RoutingStage[]
+}
 
-export type SupervisorWorkOrder = WorkOrder;
+export type SupervisorWorkOrder = WorkOrder
 
 export type KanbanWorkCenter = {
-  id: string;
-  name: string;
-  departmentId: string;
-  departmentName: string;
-  sequence: number;
-};
+  id: string
+  name: string
+  departmentId: string
+  departmentName: string
+  sequence: number
+}
 
 export type KanbanColumn = {
-  key: string;
-  label: string;
-  workOrders: WorkOrder[];
-  description?: string;
-};
+  key: string
+  label: string
+  workOrders: WorkOrder[]
+  description?: string
+}
+
+export function buildDefaultPlannedWindow() {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 8, 0, 0, 0)
+
+  if (start <= now) {
+    start.setDate(start.getDate() + 1)
+  }
+
+  const finish = new Date(start)
+  finish.setHours(16, 30, 0, 0)
+
+  const formatForInput = (date: Date) => {
+    const year = date.getFullYear().toString()
+    const month = (date.getMonth() + 1).toString().padStart(2, '0')
+    const day = date.getDate().toString().padStart(2, '0')
+    const hours = date.getHours().toString().padStart(2, '0')
+    const minutes = date.getMinutes().toString().padStart(2, '0')
+
+    return `${year}-${month}-${day}T${hours}:${minutes}`
+  }
+
+  return {
+    plannedStartDate: formatForInput(start),
+    plannedFinishDate: formatForInput(finish),
+  }
+}
 
 export function buildKanbanColumns(
   workOrders: WorkOrder[],
-  workCenters: KanbanWorkCenter[],
+  workCenters: KanbanWorkCenter[]
 ): KanbanColumn[] {
-  const backlogStatuses: WorkOrder["status"][] = [
-    "PLANNED",
-    "RELEASED",
-    "HOLD",
-  ];
-  const completedStatuses: WorkOrder["status"][] = ["COMPLETED"];
+  const backlogStatuses: WorkOrder['status'][] = ['PLANNED', 'RELEASED', 'HOLD']
+  const completedStatuses: WorkOrder['status'][] = ['COMPLETED']
 
-  const backlogOrders = workOrders.filter((wo) =>
-    backlogStatuses.includes(wo.status),
-  );
-  const completedOrders = workOrders.filter((wo) =>
-    completedStatuses.includes(wo.status),
-  );
-  const inProgressOrders = workOrders.filter(
-    (wo) => wo.status === "IN_PROGRESS",
-  );
+  const backlogOrders = workOrders.filter((wo) => backlogStatuses.includes(wo.status))
+  const completedOrders = workOrders.filter((wo) => completedStatuses.includes(wo.status))
+  const inProgressOrders = workOrders.filter((wo) => wo.status === 'IN_PROGRESS')
 
-  const workCenterBuckets = new Map<string, WorkOrder[]>();
-  const knownWorkCenterIds = new Set(workCenters.map((center) => center.id));
-  const unassigned: WorkOrder[] = [];
+  const workCenterBuckets = new Map<string, WorkOrder[]>()
+  const knownWorkCenterIds = new Set(workCenters.map((center) => center.id))
+  const unassigned: WorkOrder[] = []
 
   for (const wo of inProgressOrders) {
     if (wo.currentWorkCenterId) {
       if (!knownWorkCenterIds.has(wo.currentWorkCenterId)) {
-        unassigned.push(wo);
-        continue;
+        unassigned.push(wo)
+        continue
       }
       if (!workCenterBuckets.has(wo.currentWorkCenterId)) {
-        workCenterBuckets.set(wo.currentWorkCenterId, []);
+        workCenterBuckets.set(wo.currentWorkCenterId, [])
       }
-      workCenterBuckets.get(wo.currentWorkCenterId)!.push(wo);
+      workCenterBuckets.get(wo.currentWorkCenterId)!.push(wo)
     } else {
-      unassigned.push(wo);
+      unassigned.push(wo)
     }
   }
 
   const columns: KanbanColumn[] = [
     {
-      key: "backlog",
-      label: "Backlog",
+      key: 'backlog',
+      label: 'Backlog',
       workOrders: backlogOrders,
-      description: "Planned, released, or on hold",
+      description: 'Planned, released, or on hold',
     },
     ...workCenters.map((center) => ({
       key: `work-center-${center.id}`,
@@ -186,128 +196,117 @@ export function buildKanbanColumns(
       description: center.departmentName,
       workOrders: workCenterBuckets.get(center.id) ?? [],
     })),
-  ];
+  ]
 
   if (unassigned.length > 0) {
     columns.push({
-      key: "unassigned",
-      label: "Unassigned",
-      description: "In progress without a workstation",
+      key: 'unassigned',
+      label: 'Unassigned',
+      description: 'In progress without a workstation',
       workOrders: unassigned,
-    });
+    })
   }
 
   columns.push({
-    key: "completed",
-    label: "Completed",
-    description: "Finished work orders",
+    key: 'completed',
+    label: 'Completed',
+    description: 'Finished work orders',
     workOrders: completedOrders,
-  });
+  })
 
-  return columns;
+  return columns
 }
 
 export default function SupervisorView() {
-  const [activeTab, setActiveTab] = useState<"board">("board");
-  const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
-  const [summary, setSummary] = useState<any>(null);
-  const [selectedDepartment, setSelectedDepartment] = useState<string>("");
-  const [userRole, setUserRole] = useState<string>("");
-  const [userDepartmentId, setUserDepartmentId] = useState<string>("");
-  const [loading, setLoading] = useState(false);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [error, setError] = useState("");
-  const [message, setMessage] = useState("");
-  const [viewMode, setViewMode] = useState<"table" | "kanban">("table");
-  const [selectedWorkOrder, setSelectedWorkOrder] = useState<WorkOrder | null>(
-    null,
-  );
-  const [isDetailDrawerOpen, setIsDetailDrawerOpen] = useState(false);
-  const [editedWorkOrder, setEditedWorkOrder] = useState<any>(null);
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  const [isEditingPlanningDetails, setIsEditingPlanningDetails] =
-    useState(false);
-  const [versionHistory, setVersionHistory] = useState<any[]>([]);
-  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<'board'>('board')
+  const [workOrders, setWorkOrders] = useState<WorkOrder[]>([])
+  const [summary, setSummary] = useState<any>(null)
+  const [selectedDepartment, setSelectedDepartment] = useState<string>('')
+  const [userRole, setUserRole] = useState<string>('')
+  const [userDepartmentId, setUserDepartmentId] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+  const [isInitialLoad, setIsInitialLoad] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [error, setError] = useState('')
+  const [message, setMessage] = useState('')
+  const [viewMode, setViewMode] = useState<'table' | 'kanban'>('table')
+  const [selectedWorkOrder, setSelectedWorkOrder] = useState<WorkOrder | null>(null)
+  const [isDetailDrawerOpen, setIsDetailDrawerOpen] = useState(false)
+  const [editedWorkOrder, setEditedWorkOrder] = useState<any>(null)
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+  const [isEditingPlanningDetails, setIsEditingPlanningDetails] = useState(false)
+  const [versionHistory, setVersionHistory] = useState<any[]>([])
+  const router = useRouter()
 
   // Plan tab states
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [newWO, setNewWO] = useState({
-    number: "",
-    hullId: "",
-    productSku: "",
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
+  const [newWO, setNewWO] = useState(() => ({
+    number: '',
+    hullId: '',
+    productSku: '',
     qty: 1,
-    model: "",
-    trim: "",
-    features: "",
-    priority: "NORMAL" as "LOW" | "NORMAL" | "HIGH" | "CRITICAL",
-    plannedStartDate: "",
-    plannedFinishDate: "",
-  });
+    model: '',
+    trim: '',
+    features: '',
+    priority: 'NORMAL' as 'LOW' | 'NORMAL' | 'HIGH' | 'CRITICAL',
+    ...buildDefaultPlannedWindow(),
+  }))
   // Model/Trim selector states
-  const [selectedModelId, setSelectedModelId] = useState("");
-  const [selectedTrimId, setSelectedTrimId] = useState("");
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
-  const [generatedSku, setGeneratedSku] = useState("");
+  const [selectedModelId, setSelectedModelId] = useState('')
+  const [selectedTrimId, setSelectedTrimId] = useState('')
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear())
+  const [generatedSku, setGeneratedSku] = useState('')
   // Detail drawer tab state
   const [activeDetailTab, setActiveDetailTab] = useState<
-    "details" | "timeline" | "notes" | "files" | "versions"
-  >("details");
-  const [routingVersions, setRoutingVersions] = useState<RoutingVersion[]>([]);
-  const [selectedRoutingVersion, setSelectedRoutingVersion] =
-    useState<RoutingVersion | null>(null);
-  const [editableStages, setEditableStages] = useState<RoutingStage[]>([]);
+    'details' | 'timeline' | 'notes' | 'files' | 'versions'
+  >('details')
+  const [routingVersions, setRoutingVersions] = useState<RoutingVersion[]>([])
+  const [selectedRoutingVersion, setSelectedRoutingVersion] = useState<RoutingVersion | null>(null)
+  const [editableStages, setEditableStages] = useState<RoutingStage[]>([])
   const [workCenters, setWorkCenters] = useState<
     Array<{
-      id: string;
-      name: string;
-      departmentId: string;
-      departmentName?: string;
+      id: string
+      name: string
+      departmentId: string
+      departmentName?: string
     }>
-  >([]);
-  const [kanbanWorkCenters, setKanbanWorkCenters] = useState<
-    KanbanWorkCenter[]
-  >([]);
-  const [routingMode, setRoutingMode] = useState<
-    "default" | "create_new" | "existing"
-  >("default");
-  const [availableRoutingVersions, setAvailableRoutingVersions] = useState<
-    any[]
-  >([]);
-  const [loadingRoutings, setLoadingRoutings] = useState(false);
+  >([])
+  const [kanbanWorkCenters, setKanbanWorkCenters] = useState<KanbanWorkCenter[]>([])
+  const [routingMode, setRoutingMode] = useState<'default' | 'create_new' | 'existing'>('default')
+  const [availableRoutingVersions, setAvailableRoutingVersions] = useState<any[]>([])
+  const [loadingRoutings, setLoadingRoutings] = useState(false)
 
   // Check authentication and user role
   useEffect(() => {
-    fetch("/api/auth/me", {
-      credentials: "include",
+    fetch('/api/auth/me', {
+      credentials: 'include',
     })
       .then((res) => res.json())
       .then((authData) => {
         if (!authData.ok) {
-          router.push("/login");
-          return;
+          router.push('/login')
+          return
         }
-        if (authData.user.role === "OPERATOR") {
-          router.push("/operator");
-          return;
+        if (authData.user.role === 'OPERATOR') {
+          router.push('/operator')
+          return
         }
-        setUserRole(authData.user.role);
-        setUserDepartmentId(authData.user.departmentId || "");
-        setSelectedDepartment(authData.user.departmentId || "");
-        loadBoardData({ trigger: "initial" });
-        loadWorkCenters();
+        setUserRole(authData.user.role)
+        setUserDepartmentId(authData.user.departmentId || '')
+        setSelectedDepartment(authData.user.departmentId || '')
+        loadBoardData({ trigger: 'initial' })
+        loadWorkCenters()
       })
-      .catch(() => router.push("/login"));
-  }, [router]);
+      .catch(() => router.push('/login'))
+  }, [router])
 
   // Load work centers for planning
   const loadWorkCenters = async () => {
     try {
-      const response = await fetch("/api/work-centers", {
-        credentials: "include",
-      });
-      const result = await response.json();
+      const response = await fetch('/api/work-centers', {
+        credentials: 'include',
+      })
+      const result = await response.json()
 
       if (result.success && result.workCenters) {
         setWorkCenters(
@@ -316,392 +315,382 @@ export default function SupervisorView() {
             name: wc.name,
             departmentId: wc.departmentId,
             departmentName: wc.department?.name,
-          })),
-        );
+          }))
+        )
       }
     } catch (error) {
-      console.error("Error loading work centers:", error);
+      console.error('Error loading work centers:', error)
       // Fallback to empty array if API fails
-      setWorkCenters([]);
+      setWorkCenters([])
     }
-  };
+  }
 
   // Load board data
   const loadBoardData = useCallback(
-    async (options?: { trigger?: "initial" | "poll" | "manual" }) => {
-      const trigger =
-        options?.trigger ?? (isInitialLoad ? "initial" : "manual");
+    async (options?: { trigger?: 'initial' | 'poll' | 'manual' }) => {
+      const trigger = options?.trigger ?? (isInitialLoad ? 'initial' : 'manual')
 
-      if (trigger === "poll") {
-        setIsRefreshing(true);
+      if (trigger === 'poll') {
+        setIsRefreshing(true)
       }
 
-      if (trigger === "initial" && isInitialLoad) {
-        setLoading(true);
+      if (trigger === 'initial' && isInitialLoad) {
+        setLoading(true)
       }
 
       try {
-        const response = await fetch("/api/supervisor/dashboard", {
-          credentials: "include",
-        });
-        const result = await response.json();
+        const response = await fetch('/api/supervisor/dashboard', {
+          credentials: 'include',
+        })
+        const result = await response.json()
 
         if (result.success) {
           // Transform the WIP data to work orders
-          const transformedOrders: WorkOrder[] = result.data.wipData.map(
-            (item: any) => {
-              const stageWorkCenter = item.currentStage?.workCenter ?? null;
-              const stageDepartment = item.currentStage?.department ?? null;
+          const transformedOrders: WorkOrder[] = result.data.wipData.map((item: any) => {
+            const stageWorkCenter = item.currentStage?.workCenter ?? null
+            const stageDepartment = item.currentStage?.department ?? null
 
-              return {
-                id: item.id,
-                number: item.number,
-                hullId: item.hullId,
-                productSku: item.productSku,
-                status: item.status,
-                qty: item.qty,
-                currentStageIndex: 0,
-                specSnapshot: {},
-                createdAt: item.createdAt,
-                plannedStartDate: item.plannedStartDate ?? null,
-                plannedFinishDate: item.plannedFinishDate ?? null,
-                priority: item.priority,
-                currentWorkCenterId: stageWorkCenter?.id ?? null,
-                currentWorkCenterName: stageWorkCenter?.name ?? null,
-                currentDepartmentName: stageDepartment?.name ?? null,
-                _count: item._count, // Pass through count data for badges
-                currentStage: item.currentStage
-                  ? {
-                      id: item.currentStage.id || "",
-                      code: item.currentStage.code,
-                      name: item.currentStage.name,
-                      sequence: item.currentStage.sequence,
-                      workCenter: stageWorkCenter,
-                      department: stageDepartment,
-                      standardSeconds: 0,
-                    }
-                  : undefined,
-              };
-            },
-          );
-          setWorkOrders(transformedOrders);
-          setSummary(result.data.summary);
+            return {
+              id: item.id,
+              number: item.number,
+              hullId: item.hullId,
+              productSku: item.productSku,
+              status: item.status,
+              qty: item.qty,
+              currentStageIndex: 0,
+              specSnapshot: {},
+              createdAt: item.createdAt,
+              plannedStartDate: item.plannedStartDate ?? null,
+              plannedFinishDate: item.plannedFinishDate ?? null,
+              priority: item.priority,
+              currentWorkCenterId: stageWorkCenter?.id ?? null,
+              currentWorkCenterName: stageWorkCenter?.name ?? null,
+              currentDepartmentName: stageDepartment?.name ?? null,
+              _count: item._count, // Pass through count data for badges
+              currentStage: item.currentStage
+                ? {
+                    id: item.currentStage.id || '',
+                    code: item.currentStage.code,
+                    name: item.currentStage.name,
+                    sequence: item.currentStage.sequence,
+                    workCenter: stageWorkCenter,
+                    department: stageDepartment,
+                    standardSeconds: 0,
+                  }
+                : undefined,
+            }
+          })
+          setWorkOrders(transformedOrders)
+          setSummary(result.data.summary)
           if (Array.isArray(result.data.workCenters)) {
-            setKanbanWorkCenters(result.data.workCenters);
+            setKanbanWorkCenters(result.data.workCenters)
           } else {
-            setKanbanWorkCenters([]);
+            setKanbanWorkCenters([])
           }
         } else {
-          setError(result.error || "Failed to load dashboard");
+          setError(result.error || 'Failed to load dashboard')
         }
       } catch (err) {
-        setError("Network error loading dashboard");
+        setError('Network error loading dashboard')
       } finally {
-        if (trigger === "poll") {
-          setIsRefreshing(false);
+        if (trigger === 'poll') {
+          setIsRefreshing(false)
         }
 
-        if (trigger === "initial" && isInitialLoad) {
-          setLoading(false);
+        if (trigger === 'initial' && isInitialLoad) {
+          setLoading(false)
         }
 
         if (isInitialLoad) {
-          setIsInitialLoad(false);
+          setIsInitialLoad(false)
         }
       }
     },
-    [isInitialLoad],
-  );
+    [isInitialLoad]
+  )
 
   // Poll for updates
   useEffect(() => {
-    if (activeTab === "board") {
-      const interval = setInterval(
-        () => loadBoardData({ trigger: "poll" }),
-        10000,
-      ); // Poll every 10 seconds
-      return () => clearInterval(interval);
+    if (activeTab === 'board') {
+      const interval = setInterval(() => loadBoardData({ trigger: 'poll' }), 10000) // Poll every 10 seconds
+      return () => clearInterval(interval)
     }
-  }, [activeTab, loadBoardData]);
+  }, [activeTab, loadBoardData])
 
   // Load work order details
   const loadWorkOrderDetails = async (woId: string) => {
     try {
       const response = await fetch(`/api/work-orders/${woId}`, {
-        credentials: "include",
-      });
+        credentials: 'include',
+      })
 
       if (response.ok) {
-        const data = await response.json();
-        openDetailDrawer(data.workOrder);
+        const data = await response.json()
+        openDetailDrawer(data.workOrder)
       } else {
-        const data = await response.json();
-        setError(data.error || "Failed to load work order details");
+        const data = await response.json()
+        setError(data.error || 'Failed to load work order details')
       }
     } catch (err) {
-      setError("Network error loading work order details");
+      setError('Network error loading work order details')
     }
-  };
+  }
 
   // Hold work order
   const holdWorkOrder = async (woId: string) => {
-    const reason = prompt("Please enter reason for hold:");
-    if (!reason) return;
+    const reason = prompt('Please enter reason for hold:')
+    if (!reason) return
 
-    setLoading(true);
+    setLoading(true)
     try {
       const response = await fetch(`/api/work-orders/${woId}/hold`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ reason }),
-      });
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok && data.success) {
-        setMessage(data.message);
-        await loadBoardData({ trigger: "manual" });
-        setTimeout(() => setMessage(""), 3000);
+        setMessage(data.message)
+        await loadBoardData({ trigger: 'manual' })
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(data.error || "Failed to hold work order");
+        setError(data.error || 'Failed to hold work order')
       }
     } catch (err) {
-      setError("Network error holding work order");
+      setError('Network error holding work order')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   // Unhold work order
   const unholdWorkOrder = async (woId: string) => {
-    setLoading(true);
+    setLoading(true)
     try {
       const response = await fetch(`/api/work-orders/${woId}/unhold`, {
-        method: "POST",
-        credentials: "include",
-      });
+        method: 'POST',
+        credentials: 'include',
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok && data.success) {
-        setMessage(data.message);
-        await loadBoardData({ trigger: "manual" });
-        setTimeout(() => setMessage(""), 3000);
+        setMessage(data.message)
+        await loadBoardData({ trigger: 'manual' })
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(data.error || "Failed to unhold work order");
+        setError(data.error || 'Failed to unhold work order')
       }
     } catch (err) {
-      setError("Network error unholding work order");
+      setError('Network error unholding work order')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   // Create work order
   // Load routing versions for selected product configuration
   const loadRoutingVersions = async (model: string, trim?: string) => {
-    if (!model) return;
+    if (!model) return
 
-    setLoadingRoutings(true);
+    setLoadingRoutings(true)
     try {
-      const params = new URLSearchParams({ model });
-      if (trim) params.append("trim", trim);
+      const params = new URLSearchParams({ model })
+      if (trim) params.append('trim', trim)
 
       const response = await fetch(`/api/routing-versions?${params}`, {
-        credentials: "include",
-      });
-      const result = await response.json();
+        credentials: 'include',
+      })
+      const result = await response.json()
 
       if (result.success) {
-        setAvailableRoutingVersions(result.routingVersions);
+        setAvailableRoutingVersions(result.routingVersions)
       }
     } catch (error) {
-      console.error("Error loading routing versions:", error);
+      console.error('Error loading routing versions:', error)
     }
-    setLoadingRoutings(false);
-  };
+    setLoadingRoutings(false)
+  }
 
   // Create default routing with all 11 departments
   const createDefaultRouting = () => {
     if (workCenters.length === 0) {
-      setError("Work centers not loaded yet. Please try again.");
-      return;
+      setError('Work centers not loaded yet. Please try again.')
+      return
     }
 
     // Create complete routing with all 11 departments in correct order
     const departmentOrder = [
-      "Kitting",
-      "Lamination",
-      "Hull Rigging",
-      "Deck Rigging",
-      "Capping",
-      "Engine Hang",
-      "Final Rigging",
-      "Water Test",
-      "QA",
-      "Cleaning",
-      "Shipping",
-    ];
+      'Kitting',
+      'Lamination',
+      'Hull Rigging',
+      'Deck Rigging',
+      'Capping',
+      'Engine Hang',
+      'Final Rigging',
+      'Water Test',
+      'QA',
+      'Cleaning',
+      'Shipping',
+    ]
 
     // Validate that all departments have work centers
-    const missingDepartments: string[] = [];
+    const missingDepartments: string[] = []
     const defaultStages = departmentOrder
       .map((deptName, index) => {
-        const workCenter = workCenters.find(
-          (wc) => wc.departmentName === deptName,
-        );
+        const workCenter = workCenters.find((wc) => wc.departmentName === deptName)
         if (!workCenter) {
-          missingDepartments.push(deptName);
-          return null;
+          missingDepartments.push(deptName)
+          return null
         }
 
         return {
-          code: deptName.toUpperCase().replace(/\s+/g, "_"),
+          code: deptName.toUpperCase().replace(/\s+/g, '_'),
           name: deptName,
           sequence: index + 1,
           enabled: true,
           workCenterId: workCenter.id,
           standardStageSeconds: getDefaultTimeForDepartment(deptName),
-        };
+        }
       })
-      .filter(Boolean) as RoutingStage[];
+      .filter(Boolean) as RoutingStage[]
 
     if (missingDepartments.length > 0) {
       setError(
-        `Missing work centers for departments: ${missingDepartments.join(", ")}. Please ensure all departments have active work centers.`,
-      );
-      return;
+        `Missing work centers for departments: ${missingDepartments.join(', ')}. Please ensure all departments have active work centers.`
+      )
+      return
     }
 
-    setEditableStages(defaultStages);
+    setEditableStages(defaultStages)
     setSelectedRoutingVersion({
-      id: "default",
+      id: 'default',
       model: newWO.model,
       trim: newWO.trim,
-    } as any);
-  };
+    } as any)
+  }
 
   // Get default time allocation for each department
   const getDefaultTimeForDepartment = (deptName: string): number => {
     const timeMap: Record<string, number> = {
       Kitting: 7200, // 2 hours
       Lamination: 14400, // 4 hours
-      "Hull Rigging": 10800, // 3 hours
-      "Deck Rigging": 9000, // 2.5 hours
+      'Hull Rigging': 10800, // 3 hours
+      'Deck Rigging': 9000, // 2.5 hours
       Capping: 5400, // 1.5 hours
-      "Engine Hang": 7200, // 2 hours
-      "Final Rigging": 10800, // 3 hours
-      "Water Test": 3600, // 1 hour
+      'Engine Hang': 7200, // 2 hours
+      'Final Rigging': 10800, // 3 hours
+      'Water Test': 3600, // 1 hour
       QA: 5400, // 1.5 hours
       Cleaning: 3600, // 1 hour
       Shipping: 1800, // 0.5 hours
-    };
-    return timeMap[deptName] || 3600;
-  };
+    }
+    return timeMap[deptName] || 3600
+  }
 
   // Handle routing mode changes
   const handleRoutingModeChange = (
-    mode: "default" | "create_new" | "existing",
-    routingVersionId?: string,
+    mode: 'default' | 'create_new' | 'existing',
+    routingVersionId?: string
   ) => {
-    setRoutingMode(mode);
+    setRoutingMode(mode)
 
-    if (mode === "default") {
-      createDefaultRouting();
-    } else if (mode === "create_new") {
-      setEditableStages([]);
-      setSelectedRoutingVersion(null);
-    } else if (mode === "existing" && routingVersionId) {
-      const selectedVersion = availableRoutingVersions.find(
-        (rv) => rv.id === routingVersionId,
-      );
+    if (mode === 'default') {
+      createDefaultRouting()
+    } else if (mode === 'create_new') {
+      setEditableStages([])
+      setSelectedRoutingVersion(null)
+    } else if (mode === 'existing' && routingVersionId) {
+      const selectedVersion = availableRoutingVersions.find((rv) => rv.id === routingVersionId)
       if (selectedVersion) {
-        setSelectedRoutingVersion(selectedVersion);
-        setEditableStages(selectedVersion.stages || []);
+        setSelectedRoutingVersion(selectedVersion)
+        setEditableStages(selectedVersion.stages || [])
       }
     }
-  };
+  }
 
   // Save current routing as new version
   const saveCurrentRouting = async () => {
     if (!newWO.model || editableStages.length === 0) {
-      setError("Please configure routing stages before saving");
-      return;
+      setError('Please configure routing stages before saving')
+      return
     }
 
     try {
-      const response = await fetch("/api/routing-versions/clone", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+      const response = await fetch('/api/routing-versions/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
           model: newWO.model,
           trim: newWO.trim || undefined,
           features: newWO.features || undefined,
           stages: editableStages,
         }),
-      });
+      })
 
-      const result = await response.json();
+      const result = await response.json()
 
       if (result.success) {
-        setMessage("Routing configuration saved successfully");
-        await loadRoutingVersions(newWO.model, newWO.trim);
-        setTimeout(() => setMessage(""), 3000);
+        setMessage('Routing configuration saved successfully')
+        await loadRoutingVersions(newWO.model, newWO.trim)
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(result.error || "Failed to save routing configuration");
+        setError(result.error || 'Failed to save routing configuration')
       }
     } catch (error) {
-      setError("Network error saving routing configuration");
+      setError('Network error saving routing configuration')
     }
-  };
+  }
 
   // Load routing versions when model/trim changes
   useEffect(() => {
     if (newWO.model) {
-      loadRoutingVersions(newWO.model, newWO.trim);
+      loadRoutingVersions(newWO.model, newWO.trim)
     }
-  }, [newWO.model, newWO.trim]);
+  }, [newWO.model, newWO.trim])
 
   const createWorkOrder = async () => {
     if (!newWO.hullId || !newWO.model) {
-      setError("Hull ID and Model are required");
-      return;
+      setError('Hull ID and Model are required')
+      return
     }
 
     if (editableStages.length === 0) {
-      setError("Please configure routing stages");
-      return;
+      setError('Please configure routing stages')
+      return
     }
 
-    setLoading(true);
+    setLoading(true)
     try {
       // First create/clone the routing version with edited stages
-      const routingResponse = await fetch("/api/routing-versions/clone", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+      const routingResponse = await fetch('/api/routing-versions/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
           model: newWO.model,
           trim: newWO.trim || undefined,
           features: newWO.features || undefined,
           stages: editableStages,
         }),
-      });
+      })
 
-      const routingData = await routingResponse.json();
+      const routingData = await routingResponse.json()
 
       if (!routingResponse.ok || !routingData.success) {
-        setError(routingData.error || "Failed to create routing version");
-        return;
+        setError(routingData.error || 'Failed to create routing version')
+        return
       }
 
       // Then create the work order
-      const woResponse = await fetch("/api/work-orders", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+      const woResponse = await fetch('/api/work-orders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
           number: newWO.number || undefined,
           hullId: newWO.hullId,
@@ -719,107 +708,104 @@ export default function SupervisorView() {
             ? new Date(newWO.plannedFinishDate).toISOString()
             : null,
         }),
-      });
+      })
 
-      const woData = await woResponse.json();
+      const woData = await woResponse.json()
 
       if (woResponse.ok && woData.success) {
-        setMessage(
-          `Work order ${woData.workOrder.number} created successfully`,
-        );
-        setIsCreateModalOpen(false);
+        setMessage(`Work order ${woData.workOrder.number} created successfully`)
+        setIsCreateModalOpen(false)
         setNewWO({
-          number: "",
-          hullId: "",
-          productSku: "",
+          number: '',
+          hullId: '',
+          productSku: '',
           qty: 1,
-          model: "",
-          trim: "",
-          features: "",
-          priority: "NORMAL",
-          plannedStartDate: "",
-          plannedFinishDate: "",
-        });
-        setSelectedRoutingVersion(null);
-        setEditableStages([]);
-        await loadBoardData({ trigger: "manual" });
-        setTimeout(() => setMessage(""), 3000);
+          model: '',
+          trim: '',
+          features: '',
+          priority: 'NORMAL',
+          ...buildDefaultPlannedWindow(),
+        })
+        setSelectedRoutingVersion(null)
+        setEditableStages([])
+        await loadBoardData({ trigger: 'manual' })
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(woData.error || "Failed to create work order");
+        setError(woData.error || 'Failed to create work order')
       }
     } catch (err) {
-      setError("Network error creating work order");
+      setError('Network error creating work order')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   // Release work order
   const releaseWorkOrder = async (woId: string) => {
-    setLoading(true);
+    setLoading(true)
     try {
       const response = await fetch(`/api/work-orders/${woId}/release`, {
-        method: "POST",
-        credentials: "include",
-      });
+        method: 'POST',
+        credentials: 'include',
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok && data.success) {
-        setMessage(data.message);
-        await loadBoardData({ trigger: "manual" });
-        setTimeout(() => setMessage(""), 3000);
+        setMessage(data.message)
+        await loadBoardData({ trigger: 'manual' })
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(data.error || "Failed to release work order");
+        setError(data.error || 'Failed to release work order')
       }
     } catch (err) {
-      setError("Network error releasing work order");
+      setError('Network error releasing work order')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   const loadVersionHistory = async (woId: string) => {
     try {
       const response = await fetch(`/api/work-orders/${woId}/versions`, {
-        credentials: "include",
-      });
-      const data = await response.json();
+        credentials: 'include',
+      })
+      const data = await response.json()
       if (response.ok && data.success) {
-        setVersionHistory(data.versions || []);
+        setVersionHistory(data.versions || [])
       }
     } catch (err) {
-      console.error("Error loading version history:", err);
+      console.error('Error loading version history:', err)
     }
-  };
+  }
 
   const openDetailDrawer = (wo: WorkOrder) => {
-    setSelectedWorkOrder(wo);
+    setSelectedWorkOrder(wo)
     setEditedWorkOrder({
-      priority: wo.priority || "NORMAL",
+      priority: wo.priority || 'NORMAL',
       plannedStartDate: wo.plannedStartDate
         ? new Date(wo.plannedStartDate).toISOString().slice(0, 16)
-        : "",
+        : '',
       plannedFinishDate: wo.plannedFinishDate
         ? new Date(wo.plannedFinishDate).toISOString().slice(0, 16)
-        : "",
-    });
-    setHasUnsavedChanges(false);
-    setIsEditingPlanningDetails(false);
-    setIsDetailDrawerOpen(true);
-    setActiveDetailTab("details");
-    loadVersionHistory(wo.id);
-  };
+        : '',
+    })
+    setHasUnsavedChanges(false)
+    setIsEditingPlanningDetails(false)
+    setIsDetailDrawerOpen(true)
+    setActiveDetailTab('details')
+    loadVersionHistory(wo.id)
+  }
 
   const saveWorkOrderChanges = async () => {
-    if (!selectedWorkOrder || !editedWorkOrder) return;
+    if (!selectedWorkOrder || !editedWorkOrder) return
 
-    setLoading(true);
+    setLoading(true)
     try {
       const response = await fetch(`/api/work-orders/${selectedWorkOrder.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
           priority: editedWorkOrder.priority,
           plannedStartDate: editedWorkOrder.plannedStartDate
@@ -829,294 +815,277 @@ export default function SupervisorView() {
             ? new Date(editedWorkOrder.plannedFinishDate).toISOString()
             : null,
         }),
-      });
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok && data.success) {
-        setMessage("Changes saved successfully");
-        setHasUnsavedChanges(false);
-        setIsEditingPlanningDetails(false);
+        setMessage('Changes saved successfully')
+        setHasUnsavedChanges(false)
+        setIsEditingPlanningDetails(false)
 
         // Refresh the work order details to get the latest server state
-        const refreshResponse = await fetch(
-          `/api/work-orders/${selectedWorkOrder.id}`,
-          {
-            credentials: "include",
-          },
-        );
+        const refreshResponse = await fetch(`/api/work-orders/${selectedWorkOrder.id}`, {
+          credentials: 'include',
+        })
 
         if (refreshResponse.ok) {
-          const refreshData = await refreshResponse.json();
-          setSelectedWorkOrder(refreshData.workOrder);
+          const refreshData = await refreshResponse.json()
+          setSelectedWorkOrder(refreshData.workOrder)
           setEditedWorkOrder({
-            priority: refreshData.workOrder.priority || "NORMAL",
+            priority: refreshData.workOrder.priority || 'NORMAL',
             plannedStartDate: refreshData.workOrder.plannedStartDate
-              ? new Date(refreshData.workOrder.plannedStartDate)
-                  .toISOString()
-                  .slice(0, 16)
-              : "",
+              ? new Date(refreshData.workOrder.plannedStartDate).toISOString().slice(0, 16)
+              : '',
             plannedFinishDate: refreshData.workOrder.plannedFinishDate
-              ? new Date(refreshData.workOrder.plannedFinishDate)
-                  .toISOString()
-                  .slice(0, 16)
-              : "",
-          });
+              ? new Date(refreshData.workOrder.plannedFinishDate).toISOString().slice(0, 16)
+              : '',
+          })
         }
 
-        await loadBoardData({ trigger: "manual" });
-        loadVersionHistory(selectedWorkOrder.id);
-        setTimeout(() => setMessage(""), 3000);
+        await loadBoardData({ trigger: 'manual' })
+        loadVersionHistory(selectedWorkOrder.id)
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(data.error || "Failed to save changes");
+        setError(data.error || 'Failed to save changes')
       }
     } catch (err) {
-      setError("Network error saving changes");
+      setError('Network error saving changes')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   const discardWorkOrderChanges = () => {
     if (selectedWorkOrder) {
       setEditedWorkOrder({
-        priority: selectedWorkOrder.priority || "NORMAL",
+        priority: selectedWorkOrder.priority || 'NORMAL',
         plannedStartDate: selectedWorkOrder.plannedStartDate
-          ? new Date(selectedWorkOrder.plannedStartDate)
-              .toISOString()
-              .slice(0, 16)
-          : "",
+          ? new Date(selectedWorkOrder.plannedStartDate).toISOString().slice(0, 16)
+          : '',
         plannedFinishDate: selectedWorkOrder.plannedFinishDate
-          ? new Date(selectedWorkOrder.plannedFinishDate)
-              .toISOString()
-              .slice(0, 16)
-          : "",
-      });
-      setHasUnsavedChanges(false);
-      setIsEditingPlanningDetails(false);
+          ? new Date(selectedWorkOrder.plannedFinishDate).toISOString().slice(0, 16)
+          : '',
+      })
+      setHasUnsavedChanges(false)
+      setIsEditingPlanningDetails(false)
     }
-  };
+  }
 
   const cancelWorkOrder = async (woId: string) => {
-    setLoading(true);
+    setLoading(true)
     try {
-      const response = await fetch("/api/supervisor/cancel-wo", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+      const response = await fetch('/api/supervisor/cancel-wo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ workOrderId: woId }),
-      });
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok && data.success) {
-        setMessage("Work order cancelled successfully");
-        setIsDetailDrawerOpen(false);
-        setSelectedWorkOrder(null);
-        setEditedWorkOrder(null);
-        setHasUnsavedChanges(false);
-        setIsEditingPlanningDetails(false);
-        setActiveDetailTab("details");
-        await loadBoardData({ trigger: "manual" });
-        setTimeout(() => setMessage(""), 3000);
+        setMessage('Work order cancelled successfully')
+        setIsDetailDrawerOpen(false)
+        setSelectedWorkOrder(null)
+        setEditedWorkOrder(null)
+        setHasUnsavedChanges(false)
+        setIsEditingPlanningDetails(false)
+        setActiveDetailTab('details')
+        await loadBoardData({ trigger: 'manual' })
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(data.error || "Failed to cancel work order");
+        setError(data.error || 'Failed to cancel work order')
       }
     } catch (err) {
-      setError("Network error cancelling work order");
+      setError('Network error cancelling work order')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   const uncancelWorkOrder = async (woId: string) => {
-    setLoading(true);
+    setLoading(true)
     try {
-      const response = await fetch("/api/supervisor/uncancel-wo", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
+      const response = await fetch('/api/supervisor/uncancel-wo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ workOrderId: woId }),
-      });
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok && data.success) {
-        setMessage("Work order restored to PLANNED status");
-        await loadBoardData({ trigger: "manual" });
-        setTimeout(() => setMessage(""), 3000);
+        setMessage('Work order restored to PLANNED status')
+        await loadBoardData({ trigger: 'manual' })
+        setTimeout(() => setMessage(''), 3000)
       } else {
-        setError(data.error || "Failed to restore work order");
+        setError(data.error || 'Failed to restore work order')
       }
     } catch (err) {
-      setError("Network error restoring work order");
+      setError('Network error restoring work order')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   // Toggle stage enabled status
   const toggleStageEnabled = (index: number) => {
-    const newStages = [...editableStages];
-    newStages[index].enabled = !newStages[index].enabled;
-    setEditableStages(newStages);
-  };
+    const newStages = [...editableStages]
+    newStages[index].enabled = !newStages[index].enabled
+    setEditableStages(newStages)
+  }
 
   // Move stage up
   const moveStageUp = (index: number) => {
-    if (index === 0) return;
-    const newStages = [...editableStages];
-    const temp = newStages[index - 1];
-    newStages[index - 1] = newStages[index];
-    newStages[index] = temp;
+    if (index === 0) return
+    const newStages = [...editableStages]
+    const temp = newStages[index - 1]
+    newStages[index - 1] = newStages[index]
+    newStages[index] = temp
     // Update sequences
     newStages.forEach((stage, i) => {
-      stage.sequence = i + 1;
-    });
-    setEditableStages(newStages);
-  };
+      stage.sequence = i + 1
+    })
+    setEditableStages(newStages)
+  }
 
   // Move stage down
   const moveStageDown = (index: number) => {
-    if (index === editableStages.length - 1) return;
-    const newStages = [...editableStages];
-    const temp = newStages[index + 1];
-    newStages[index + 1] = newStages[index];
-    newStages[index] = temp;
+    if (index === editableStages.length - 1) return
+    const newStages = [...editableStages]
+    const temp = newStages[index + 1]
+    newStages[index + 1] = newStages[index]
+    newStages[index] = temp
     // Update sequences
     newStages.forEach((stage, i) => {
-      stage.sequence = i + 1;
-    });
-    setEditableStages(newStages);
-  };
+      stage.sequence = i + 1
+    })
+    setEditableStages(newStages)
+  }
 
   // Update stage seconds
   const updateStageSeconds = (index: number, seconds: number) => {
-    const newStages = [...editableStages];
-    newStages[index].standardStageSeconds = seconds;
-    setEditableStages(newStages);
-  };
+    const newStages = [...editableStages]
+    newStages[index].standardStageSeconds = seconds
+    setEditableStages(newStages)
+  }
 
   // Get status color
   const getStatusColor = (status: string) => {
     switch (status) {
-      case "PLANNED":
+      case 'PLANNED':
         return {
-          bg: "var(--status-info-surface)",
-          color: "var(--status-info-foreground)",
-        };
-      case "RELEASED":
+          bg: 'var(--status-info-surface)',
+          color: 'var(--status-info-foreground)',
+        }
+      case 'RELEASED':
         return {
-          bg: "var(--status-info-surface)",
-          color: "var(--status-info-foreground)",
-        };
-      case "IN_PROGRESS":
+          bg: 'var(--status-info-surface)',
+          color: 'var(--status-info-foreground)',
+        }
+      case 'IN_PROGRESS':
         return {
-          bg: "var(--status-success-surface)",
-          color: "var(--status-success-foreground)",
-        };
-      case "COMPLETED":
+          bg: 'var(--status-success-surface)',
+          color: 'var(--status-success-foreground)',
+        }
+      case 'COMPLETED':
         return {
-          bg: "var(--status-maintenance-surface)",
-          color: "var(--status-maintenance-foreground)",
-        };
-      case "HOLD":
+          bg: 'var(--status-maintenance-surface)',
+          color: 'var(--status-maintenance-foreground)',
+        }
+      case 'HOLD':
         return {
-          bg: "var(--status-warning-surface)",
-          color: "var(--status-warning-foreground)",
-        };
+          bg: 'var(--status-warning-surface)',
+          color: 'var(--status-warning-foreground)',
+        }
       default:
         return {
-          bg: "var(--status-neutral-surface)",
-          color: "var(--status-neutral-foreground)",
-        };
+          bg: 'var(--status-neutral-surface)',
+          color: 'var(--status-neutral-foreground)',
+        }
     }
-  };
+  }
 
   // Render Kanban view
   const renderKanbanView = () => {
-    const columns = buildKanbanColumns(workOrders, kanbanWorkCenters);
+    const columns = buildKanbanColumns(workOrders, kanbanWorkCenters)
 
     return (
       <div
         style={{
-          backgroundColor: "var(--surface-muted)",
-          border: "1px solid var(--border)",
-          borderRadius: "8px",
-          boxShadow: "var(--shadow-card)",
-          padding: "1.25rem",
+          backgroundColor: 'var(--surface-muted)',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          boxShadow: 'var(--shadow-card)',
+          padding: '1.25rem',
         }}
       >
         <div
           style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: "1rem",
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '1rem',
           }}
         >
-          <h2 style={{ margin: 0, fontSize: "1.25rem", fontWeight: "600" }}>
-            Active Work Orders
-          </h2>
-          <Button
-            variant="success"
-            size="sm"
-            onClick={() => setIsCreateModalOpen(true)}
-          >
+          <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: '600' }}>Active Work Orders</h2>
+          <Button variant="success" size="sm" onClick={() => setIsCreateModalOpen(true)}>
             Create Work Order
           </Button>
         </div>
 
         <div
           style={{
-            position: "relative",
+            position: 'relative',
           }}
         >
           <div
             role="list"
             aria-label="Active work orders grouped by stage"
             style={{
-              display: "flex",
-              gap: "1rem",
-              overflowX: "auto",
-              padding: "0 0.25rem 0.75rem",
-              margin: "0 -0.25rem",
-              WebkitOverflowScrolling: "touch",
-              scrollSnapType: "x mandatory",
-              scrollPaddingInline: "0.25rem",
-              alignItems: "stretch",
-              scrollbarGutter: "stable both-edges",
-              touchAction: "pan-x pan-y",
+              display: 'flex',
+              gap: '1rem',
+              overflowX: 'auto',
+              padding: '0 0.25rem 0.75rem',
+              margin: '0 -0.25rem',
+              WebkitOverflowScrolling: 'touch',
+              scrollSnapType: 'x mandatory',
+              scrollPaddingInline: '0.25rem',
+              alignItems: 'stretch',
+              scrollbarGutter: 'stable both-edges',
+              touchAction: 'pan-x pan-y',
             }}
           >
             {columns.map((column) => {
-              const columnWOs = column.workOrders;
+              const columnWOs = column.workOrders
 
               return (
                 <div
                   key={column.key}
                   role="listitem"
                   style={{
-                    backgroundColor: "var(--surface)",
-                    border: "1px solid var(--border)",
-                    borderRadius: "8px",
-                    padding: "1rem",
-                    boxShadow: "var(--shadow-card-hover)",
-                    minHeight: "400px",
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "0.75rem",
-                    flex: "0 0 clamp(260px, 60vw, 340px)",
-                    scrollSnapAlign: "start",
-                    scrollMarginInline: "0.25rem",
+                    backgroundColor: 'var(--surface)',
+                    border: '1px solid var(--border)',
+                    borderRadius: '8px',
+                    padding: '1rem',
+                    boxShadow: 'var(--shadow-card-hover)',
+                    minHeight: '400px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '0.75rem',
+                    flex: '0 0 clamp(260px, 60vw, 340px)',
+                    scrollSnapAlign: 'start',
+                    scrollMarginInline: '0.25rem',
                   }}
                 >
                   <div>
                     <h3
                       style={{
-                        margin: "0 0 0.25rem 0",
-                        fontSize: "1.1rem",
-                        fontWeight: "600",
+                        margin: '0 0 0.25rem 0',
+                        fontSize: '1.1rem',
+                        fontWeight: '600',
                       }}
                     >
                       {column.label} ({columnWOs.length})
@@ -1125,8 +1094,8 @@ export default function SupervisorView() {
                       <p
                         style={{
                           margin: 0,
-                          fontSize: "0.8rem",
-                          color: "var(--muted)",
+                          fontSize: '0.8rem',
+                          color: 'var(--muted)',
                         }}
                       >
                         {column.description}
@@ -1137,148 +1106,134 @@ export default function SupervisorView() {
                   {columnWOs.length === 0 ? (
                     <div
                       style={{
-                        fontSize: "0.85rem",
-                        color: "var(--muted)",
+                        fontSize: '0.85rem',
+                        color: 'var(--muted)',
                       }}
                     >
                       No work orders
                     </div>
                   ) : (
                     columnWOs.map((wo) => {
-                      const priorityColors: Record<
-                        string,
-                        { bg: string; text: string }
-                      > = {
+                      const priorityColors: Record<string, { bg: string; text: string }> = {
                         LOW: {
-                          bg: "var(--status-success-surface)",
-                          text: "var(--status-success-foreground)",
+                          bg: 'var(--status-success-surface)',
+                          text: 'var(--status-success-foreground)',
                         },
                         NORMAL: {
-                          bg: "var(--status-info-surface)",
-                          text: "var(--status-info-foreground)",
+                          bg: 'var(--status-info-surface)',
+                          text: 'var(--status-info-foreground)',
                         },
                         HIGH: {
-                          bg: "var(--status-warning-surface)",
-                          text: "var(--status-warning-foreground)",
+                          bg: 'var(--status-warning-surface)',
+                          text: 'var(--status-warning-foreground)',
                         },
                         CRITICAL: {
-                          bg: "var(--status-danger-surface)",
-                          text: "var(--status-danger-foreground)",
+                          bg: 'var(--status-danger-surface)',
+                          text: 'var(--status-danger-foreground)',
                         },
-                      };
+                      }
                       const priorityColor =
-                        priorityColors[wo.priority || "NORMAL"] ||
-                        priorityColors.NORMAL;
-                      const stageName =
-                        wo.currentStage?.name || "Stage not assigned";
-                      const workCenterLabel =
-                        wo.currentWorkCenterName || "No work center";
-                      const departmentLabel = wo.currentDepartmentName;
+                        priorityColors[wo.priority || 'NORMAL'] || priorityColors.NORMAL
+                      const stageName = wo.currentStage?.name || 'Stage not assigned'
+                      const workCenterLabel = wo.currentWorkCenterName || 'No work center'
+                      const departmentLabel = wo.currentDepartmentName
 
                       return (
                         <div
                           key={wo.id}
                           style={{
-                            padding: "0.75rem",
-                            backgroundColor: "var(--table-header-surface)",
-                            borderRadius: "4px",
-                            border: "1px solid var(--border)",
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: "0.35rem",
+                            padding: '0.75rem',
+                            backgroundColor: 'var(--table-header-surface)',
+                            borderRadius: '4px',
+                            border: '1px solid var(--border)',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '0.35rem',
                           }}
                         >
                           <div
                             style={{
-                              display: "flex",
-                              justifyContent: "space-between",
-                              alignItems: "center",
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
                             }}
                           >
-                            <div style={{ fontWeight: "500" }}>{wo.number}</div>
-                            <div style={{ display: "flex", gap: "0.25rem" }}>
+                            <div style={{ fontWeight: '500' }}>{wo.number}</div>
+                            <div style={{ display: 'flex', gap: '0.25rem' }}>
                               {wo._count && wo._count.attachments > 0 && (
                                 <span
                                   style={{
-                                    fontSize: "0.75rem",
-                                    backgroundColor:
-                                      "var(--status-info-surface)",
-                                    color: "var(--status-info-foreground)",
-                                    padding: "0.125rem 0.25rem",
-                                    borderRadius: "10px",
-                                    fontWeight: "500",
-                                    display: "inline-flex",
-                                    alignItems: "center",
-                                    gap: "0.25rem",
-                                    position: "relative",
+                                    fontSize: '0.75rem',
+                                    backgroundColor: 'var(--status-info-surface)',
+                                    color: 'var(--status-info-foreground)',
+                                    padding: '0.125rem 0.25rem',
+                                    borderRadius: '10px',
+                                    fontWeight: '500',
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '0.25rem',
+                                    position: 'relative',
                                   }}
                                 >
                                   <span
                                     style={{
                                       border: 0,
-                                      clip: "rect(0, 0, 0, 0)",
-                                      height: "1px",
-                                      margin: "-1px",
-                                      overflow: "hidden",
+                                      clip: 'rect(0, 0, 0, 0)',
+                                      height: '1px',
+                                      margin: '-1px',
+                                      overflow: 'hidden',
                                       padding: 0,
-                                      position: "absolute",
-                                      width: "1px",
-                                      whiteSpace: "nowrap",
+                                      position: 'absolute',
+                                      width: '1px',
+                                      whiteSpace: 'nowrap',
                                     }}
                                   >
                                     {`${wo._count.attachments} attachment${
-                                      wo._count.attachments === 1 ? "" : "s"
+                                      wo._count.attachments === 1 ? '' : 's'
                                     }`}
                                   </span>
                                   <PaperClipIcon
                                     aria-hidden="true"
-                                    style={{ height: "0.75rem", width: "0.75rem" }}
+                                    style={{ height: '0.75rem', width: '0.75rem' }}
                                   />
-                                  <span aria-hidden="true">
-                                    {wo._count.attachments}
-                                  </span>
+                                  <span aria-hidden="true">{wo._count.attachments}</span>
                                 </span>
                               )}
                               {wo._count && wo._count.notes > 0 && (
                                 <span
                                   style={{
-                                    fontSize: "0.75rem",
-                                    backgroundColor:
-                                      "var(--status-success-surface)",
-                                    color: "var(--status-success-foreground)",
-                                    padding: "0.125rem 0.25rem",
-                                    borderRadius: "10px",
-                                    fontWeight: "500",
-                                    display: "inline-flex",
-                                    alignItems: "center",
-                                    gap: "0.25rem",
+                                    fontSize: '0.75rem',
+                                    backgroundColor: 'var(--status-success-surface)',
+                                    color: 'var(--status-success-foreground)',
+                                    padding: '0.125rem 0.25rem',
+                                    borderRadius: '10px',
+                                    fontWeight: '500',
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '0.25rem',
                                   }}
                                 >
                                   <span
                                     className="sr-only"
                                     style={{
-                                      position: "absolute",
-                                      width: "1px",
-                                      height: "1px",
-                                      padding: "0",
-                                      margin: "-1px",
-                                      overflow: "hidden",
-                                      clip: "rect(0, 0, 0, 0)",
-                                      whiteSpace: "nowrap",
-                                      borderWidth: "0",
+                                      position: 'absolute',
+                                      width: '1px',
+                                      height: '1px',
+                                      padding: '0',
+                                      margin: '-1px',
+                                      overflow: 'hidden',
+                                      clip: 'rect(0, 0, 0, 0)',
+                                      whiteSpace: 'nowrap',
+                                      borderWidth: '0',
                                     }}
                                   >
-                                    {`${wo._count.notes} note${
-                                      wo._count.notes === 1 ? "" : "s"
-                                    }`}
+                                    {`${wo._count.notes} note${wo._count.notes === 1 ? '' : 's'}`}
                                   </span>
                                   <ChatBubbleLeftIcon
                                     aria-hidden="true"
-                                    style={{ height: "0.75rem", width: "0.75rem" }}
+                                    style={{ height: '0.75rem', width: '0.75rem' }}
                                   />
-                                  <span aria-hidden="true">
-                                    {wo._count.notes}
-                                  </span>
+                                  <span aria-hidden="true">{wo._count.notes}</span>
                                 </span>
                               )}
                             </div>
@@ -1288,30 +1243,28 @@ export default function SupervisorView() {
                           <div>
                             <span
                               style={{
-                                fontSize: "0.75rem",
+                                fontSize: '0.75rem',
                                 backgroundColor: priorityColor.bg,
                                 color: priorityColor.text,
-                                padding: "0.125rem 0.375rem",
-                                borderRadius: "3px",
-                                fontWeight: "600",
+                                padding: '0.125rem 0.375rem',
+                                borderRadius: '3px',
+                                fontWeight: '600',
                               }}
                             >
-                              {wo.priority || "NORMAL"}
+                              {wo.priority || 'NORMAL'}
                             </span>
                           </div>
 
                           <div
                             style={{
-                              fontSize: "0.875rem",
-                              color: "var(--muted)",
+                              fontSize: '0.875rem',
+                              color: 'var(--muted)',
                             }}
                           >
-                            {wo.hullId} •{" "}
+                            {wo.hullId} •{' '}
                             {wo.routingVersion
                               ? `${wo.routingVersion.model}${
-                                  wo.routingVersion.trim
-                                    ? `-${wo.routingVersion.trim}`
-                                    : ""
+                                  wo.routingVersion.trim ? `-${wo.routingVersion.trim}` : ''
                                 }`
                               : wo.productSku}
                           </div>
@@ -1319,61 +1272,51 @@ export default function SupervisorView() {
                           {wo.plannedStartDate || wo.plannedFinishDate ? (
                             <div
                               style={{
-                                fontSize: "0.75rem",
-                                color: "var(--muted)",
+                                fontSize: '0.75rem',
+                                color: 'var(--muted)',
                               }}
                             >
                               {wo.plannedStartDate && (
                                 <div>
-                                  Start:{" "}
-                                  {new Date(
-                                    wo.plannedStartDate,
-                                  ).toLocaleDateString()}
+                                  Start: {new Date(wo.plannedStartDate).toLocaleDateString()}
                                 </div>
                               )}
                               {wo.plannedFinishDate && (
                                 <div>
-                                  Finish:{" "}
-                                  {new Date(
-                                    wo.plannedFinishDate,
-                                  ).toLocaleDateString()}
+                                  Finish: {new Date(wo.plannedFinishDate).toLocaleDateString()}
                                 </div>
                               )}
                             </div>
                           ) : null}
 
-                          <div style={{ fontSize: "0.85rem" }}>
+                          <div style={{ fontSize: '0.85rem' }}>
                             <strong>Stage:</strong> {stageName}
                           </div>
-                          <div style={{ fontSize: "0.85rem" }}>
+                          <div style={{ fontSize: '0.85rem' }}>
                             <strong>Work Center:</strong> {workCenterLabel}
-                            {departmentLabel ? ` • ${departmentLabel}` : ""}
+                            {departmentLabel ? ` • ${departmentLabel}` : ''}
                           </div>
 
                           <div
                             style={{
-                              marginTop: "0.25rem",
-                              display: "flex",
-                              gap: "0.25rem",
+                              marginTop: '0.25rem',
+                              display: 'flex',
+                              gap: '0.25rem',
                             }}
                           >
-                            <Button
-                              size="sm"
-                              onClick={() => loadWorkOrderDetails(wo.id)}
-                            >
+                            <Button size="sm" onClick={() => loadWorkOrderDetails(wo.id)}>
                               Open
                             </Button>
-                            {wo.status !== "HOLD" &&
-                              wo.status !== "COMPLETED" && (
-                                <Button
-                                  size="sm"
-                                  variant="warning"
-                                  onClick={() => holdWorkOrder(wo.id)}
-                                >
-                                  Hold
-                                </Button>
-                              )}
-                            {wo.status === "HOLD" && (
+                            {wo.status !== 'HOLD' && wo.status !== 'COMPLETED' && (
+                              <Button
+                                size="sm"
+                                variant="warning"
+                                onClick={() => holdWorkOrder(wo.id)}
+                              >
+                                Hold
+                              </Button>
+                            )}
+                            {wo.status === 'HOLD' && (
                               <Button
                                 size="sm"
                                 variant="success"
@@ -1384,112 +1327,107 @@ export default function SupervisorView() {
                             )}
                           </div>
                         </div>
-                      );
+                      )
                     })
                   )}
                 </div>
-              );
+              )
             })}
           </div>
         </div>
       </div>
-    );
-  };
+    )
+  }
 
   if (isInitialLoad) {
     return (
       <div
         style={{
-          minHeight: "100vh",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "var(--background)",
-          color: "var(--foreground)",
-          fontFamily: "var(--font-sans)",
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'var(--background)',
+          color: 'var(--foreground)',
+          fontFamily: 'var(--font-sans)',
         }}
       >
         Loading...
       </div>
-    );
+    )
   }
 
   return (
     <div
       style={{
-        minHeight: "100vh",
-        backgroundColor: "var(--background)",
-        color: "var(--foreground)",
-        fontFamily: "var(--font-sans)",
-        transition: "background-color 0.3s ease, color 0.3s ease",
+        minHeight: '100vh',
+        backgroundColor: 'var(--background)',
+        color: 'var(--foreground)',
+        fontFamily: 'var(--font-sans)',
+        transition: 'background-color 0.3s ease, color 0.3s ease',
       }}
     >
       {/* Header */}
       <div
         style={{
-          backgroundColor: "var(--surface)",
-          padding: "1rem",
-          borderBottom: "1px solid var(--border)",
-          boxShadow: "var(--shadow-card)",
-          transition:
-            "background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease",
+          backgroundColor: 'var(--surface)',
+          padding: '1rem',
+          borderBottom: '1px solid var(--border)',
+          boxShadow: 'var(--shadow-card)',
+          transition: 'background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease',
         }}
       >
-        <div style={{ maxWidth: "1400px", margin: "0 auto" }}>
+        <div style={{ maxWidth: '1400px', margin: '0 auto' }}>
           <div
             style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
             }}
           >
-            <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: "600" }}>
+            <h1 style={{ margin: 0, fontSize: '1.5rem', fontWeight: '600' }}>
               Supervisor Dashboard
             </h1>
             <div
               style={{
-                display: "flex",
-                gap: "1rem",
-                alignItems: "center",
-                color: "var(--foreground)",
+                display: 'flex',
+                gap: '1rem',
+                alignItems: 'center',
+                color: 'var(--foreground)',
               }}
             >
-              {userRole === "ADMIN" && activeTab === "board" && (
+              {userRole === 'ADMIN' && activeTab === 'board' && (
                 <Select
                   value={selectedDepartment}
-                  onChange={(event) =>
-                    setSelectedDepartment(event.target.value)
-                  }
+                  onChange={(event) => setSelectedDepartment(event.target.value)}
                   options={[
-                    { value: "", label: "All Departments" },
-                    { value: "dept1", label: "Hull Rigging" },
-                    { value: "dept2", label: "Electronics" },
-                    { value: "dept3", label: "Final Assembly" },
+                    { value: '', label: 'All Departments' },
+                    { value: 'dept1', label: 'Hull Rigging' },
+                    { value: 'dept2', label: 'Electronics' },
+                    { value: 'dept3', label: 'Final Assembly' },
                   ]}
                   fullWidth={false}
                   className="min-w-[12rem]"
                 />
               )}
-              <span style={{ fontSize: "0.875rem", color: "var(--muted)" }}>
-                Role: {userRole}
-              </span>
+              <span style={{ fontSize: '0.875rem', color: 'var(--muted)' }}>Role: {userRole}</span>
             </div>
           </div>
         </div>
       </div>
 
       {/* Main Content */}
-      <div style={{ maxWidth: "1400px", margin: "0 auto", padding: "1.5rem" }}>
+      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '1.5rem' }}>
         {/* Messages */}
         {error && (
           <div
             style={{
-              backgroundColor: "var(--status-danger-surface)",
-              color: "var(--status-danger-foreground)",
-              padding: "0.75rem",
-              borderRadius: "4px",
-              marginBottom: "1rem",
-              border: "1px solid var(--status-danger-border)",
+              backgroundColor: 'var(--status-danger-surface)',
+              color: 'var(--status-danger-foreground)',
+              padding: '0.75rem',
+              borderRadius: '4px',
+              marginBottom: '1rem',
+              border: '1px solid var(--status-danger-border)',
             }}
           >
             {error}
@@ -1499,12 +1437,12 @@ export default function SupervisorView() {
         {message && (
           <div
             style={{
-              backgroundColor: "var(--status-success-surface)",
-              color: "var(--status-success-foreground)",
-              padding: "0.75rem",
-              borderRadius: "4px",
-              marginBottom: "1rem",
-              border: "1px solid var(--status-success-border)",
+              backgroundColor: 'var(--status-success-surface)',
+              color: 'var(--status-success-foreground)',
+              padding: '0.75rem',
+              borderRadius: '4px',
+              marginBottom: '1rem',
+              border: '1px solid var(--status-success-border)',
             }}
           >
             {message}
@@ -1512,37 +1450,31 @@ export default function SupervisorView() {
         )}
 
         {/* Board Tab */}
-        {activeTab === "board" && (
+        {activeTab === 'board' && (
           <div>
             {/* KPIs */}
             <div
               style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-                gap: "1rem",
-                marginBottom: "1.5rem",
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+                gap: '1rem',
+                marginBottom: '1.5rem',
               }}
             >
               <StatsCard
                 label="Released Work Orders"
-                value={
-                  workOrders.filter((wo) => wo.status === "RELEASED").length
-                }
+                value={workOrders.filter((wo) => wo.status === 'RELEASED').length}
                 variant="default"
               />
               <StatsCard
                 label="In Progress"
-                value={
-                  workOrders.filter((wo) => wo.status === "IN_PROGRESS").length
-                }
+                value={workOrders.filter((wo) => wo.status === 'IN_PROGRESS').length}
                 variant="success"
                 trend={
                   summary?.trends?.inProgress
                     ? {
                         value: Math.abs(summary.trends.inProgress.trend),
-                        direction: summary.trends.inProgress.direction as
-                          | "up"
-                          | "down",
+                        direction: summary.trends.inProgress.direction as 'up' | 'down',
                         label: `vs weekday avg`,
                       }
                     : undefined
@@ -1550,17 +1482,13 @@ export default function SupervisorView() {
               />
               <StatsCard
                 label="Completed This Week"
-                value={
-                  workOrders.filter((wo) => wo.status === "COMPLETED").length
-                }
+                value={workOrders.filter((wo) => wo.status === 'COMPLETED').length}
                 variant="success"
                 trend={
                   summary?.trends?.completed
                     ? {
                         value: Math.abs(summary.trends.completed.trend),
-                        direction: summary.trends.completed.direction as
-                          | "up"
-                          | "down",
+                        direction: summary.trends.completed.direction as 'up' | 'down',
                         label: `vs previous week`,
                       }
                     : undefined
@@ -1568,26 +1496,24 @@ export default function SupervisorView() {
               />
               <StatsCard
                 label="On Hold"
-                value={workOrders.filter((wo) => wo.status === "HOLD").length}
+                value={workOrders.filter((wo) => wo.status === 'HOLD').length}
                 variant="warning"
               />
             </div>
 
             {/* View Toggle */}
-            <div
-              style={{ marginBottom: "1rem", display: "flex", gap: "0.5rem" }}
-            >
+            <div style={{ marginBottom: '1rem', display: 'flex', gap: '0.5rem' }}>
               <Button
                 size="sm"
-                variant={viewMode === "table" ? "primary" : "secondary"}
-                onClick={() => setViewMode("table")}
+                variant={viewMode === 'table' ? 'primary' : 'secondary'}
+                onClick={() => setViewMode('table')}
               >
                 Table View
               </Button>
               <Button
                 size="sm"
-                variant={viewMode === "kanban" ? "primary" : "secondary"}
-                onClick={() => setViewMode("kanban")}
+                variant={viewMode === 'kanban' ? 'primary' : 'secondary'}
+                onClick={() => setViewMode('kanban')}
               >
                 Kanban View
               </Button>
@@ -1595,40 +1521,38 @@ export default function SupervisorView() {
 
             {/* Work Orders Display */}
             {loading ? (
-              <div style={{ textAlign: "center", padding: "3rem" }}>
-                Loading...
-              </div>
-            ) : viewMode === "kanban" ? (
+              <div style={{ textAlign: 'center', padding: '3rem' }}>Loading...</div>
+            ) : viewMode === 'kanban' ? (
               renderKanbanView()
             ) : (
               <div
                 style={{
-                  backgroundColor: "var(--surface)",
-                  borderRadius: "8px",
-                  boxShadow: "var(--shadow-card)",
-                  padding: "1.25rem",
+                  backgroundColor: 'var(--surface)',
+                  borderRadius: '8px',
+                  boxShadow: 'var(--shadow-card)',
+                  padding: '1.25rem',
                 }}
               >
                 <div
                   style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                    marginBottom: "1rem",
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    marginBottom: '1rem',
                   }}
                 >
                   <div
                     style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "0.5rem",
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.5rem',
                     }}
                   >
                     <h2
                       style={{
                         margin: 0,
-                        fontSize: "1.25rem",
-                        fontWeight: "600",
+                        fontSize: '1.25rem',
+                        fontWeight: '600',
                       }}
                     >
                       Active Work Orders
@@ -1636,148 +1560,143 @@ export default function SupervisorView() {
                     {isRefreshing && (
                       <span
                         style={{
-                          fontSize: "0.75rem",
-                          color: "var(--muted)",
-                          backgroundColor:
-                            "var(--surface-muted, rgba(0,0,0,0.05))",
-                          borderRadius: "999px",
-                          padding: "0.25rem 0.5rem",
+                          fontSize: '0.75rem',
+                          color: 'var(--muted)',
+                          backgroundColor: 'var(--surface-muted, rgba(0,0,0,0.05))',
+                          borderRadius: '999px',
+                          padding: '0.25rem 0.5rem',
                         }}
                       >
                         Refreshing…
                       </span>
                     )}
                   </div>
-                  <Button
-                    variant="success"
-                    size="sm"
-                    onClick={() => setIsCreateModalOpen(true)}
-                  >
+                  <Button variant="success" size="sm" onClick={() => setIsCreateModalOpen(true)}>
                     Create Work Order
                   </Button>
                 </div>
 
                 <div
                   style={{
-                    backgroundColor: "var(--surface)",
-                    borderRadius: "8px",
-                    boxShadow: "var(--shadow-card)",
-                    overflow: "hidden",
+                    backgroundColor: 'var(--surface)',
+                    borderRadius: '8px',
+                    boxShadow: 'var(--shadow-card)',
+                    overflow: 'hidden',
                   }}
                 >
-                  <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                  <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                     <thead>
                       <tr
                         style={{
-                          backgroundColor: "var(--table-header-surface)",
+                          backgroundColor: 'var(--table-header-surface)',
                         }}
                       >
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Status
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           WO Number
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Hull ID
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Model
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Priority
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Planned Start
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Planned Finish
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "center",
-                            borderBottom: "2px solid var(--border)",
-                            width: "80px",
+                            padding: '0.75rem',
+                            textAlign: 'center',
+                            borderBottom: '2px solid var(--border)',
+                            width: '80px',
                           }}
                         >
                           Files
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "center",
-                            borderBottom: "2px solid var(--border)",
-                            width: "80px",
+                            padding: '0.75rem',
+                            textAlign: 'center',
+                            borderBottom: '2px solid var(--border)',
+                            width: '80px',
                           }}
                         >
                           Notes
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Current Stage
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Work Center
                         </th>
                         <th
                           style={{
-                            padding: "0.75rem",
-                            textAlign: "left",
-                            borderBottom: "2px solid var(--border)",
+                            padding: '0.75rem',
+                            textAlign: 'left',
+                            borderBottom: '2px solid var(--border)',
                           }}
                         >
                           Actions
@@ -1786,43 +1705,36 @@ export default function SupervisorView() {
                     </thead>
                     <tbody>
                       {workOrders.map((wo) => {
-                        const statusStyle = getStatusColor(wo.status);
-                        const priorityColors: Record<
-                          string,
-                          { bg: string; text: string }
-                        > = {
+                        const statusStyle = getStatusColor(wo.status)
+                        const priorityColors: Record<string, { bg: string; text: string }> = {
                           LOW: {
-                            bg: "var(--status-success-surface)",
-                            text: "var(--status-success-foreground)",
+                            bg: 'var(--status-success-surface)',
+                            text: 'var(--status-success-foreground)',
                           },
                           NORMAL: {
-                            bg: "var(--status-info-surface)",
-                            text: "var(--status-info-foreground)",
+                            bg: 'var(--status-info-surface)',
+                            text: 'var(--status-info-foreground)',
                           },
                           HIGH: {
-                            bg: "var(--status-warning-surface)",
-                            text: "var(--status-warning-foreground)",
+                            bg: 'var(--status-warning-surface)',
+                            text: 'var(--status-warning-foreground)',
                           },
                           CRITICAL: {
-                            bg: "var(--status-danger-surface)",
-                            text: "var(--status-danger-foreground)",
+                            bg: 'var(--status-danger-surface)',
+                            text: 'var(--status-danger-foreground)',
                           },
-                        };
-                        const priorityColor =
-                          priorityColors[wo.priority || "NORMAL"];
+                        }
+                        const priorityColor = priorityColors[wo.priority || 'NORMAL']
 
                         return (
-                          <tr
-                            key={wo.id}
-                            style={{ borderBottom: "1px solid var(--border)" }}
-                          >
-                            <td style={{ padding: "0.75rem" }}>
+                          <tr key={wo.id} style={{ borderBottom: '1px solid var(--border)' }}>
+                            <td style={{ padding: '0.75rem' }}>
                               <span
                                 style={{
-                                  padding: "0.25rem 0.5rem",
-                                  borderRadius: "4px",
-                                  fontSize: "0.875rem",
-                                  fontWeight: "500",
+                                  padding: '0.25rem 0.5rem',
+                                  borderRadius: '4px',
+                                  fontSize: '0.875rem',
+                                  fontWeight: '500',
                                   backgroundColor: statusStyle.bg,
                                   color: statusStyle.color,
                                 }}
@@ -1830,107 +1742,96 @@ export default function SupervisorView() {
                                 {wo.status}
                               </span>
                             </td>
-                            <td
-                              style={{ padding: "0.75rem", fontWeight: "500" }}
-                            >
-                              {wo.number}
-                            </td>
-                            <td style={{ padding: "0.75rem" }}>{wo.hullId}</td>
-                            <td style={{ padding: "0.75rem" }}>
+                            <td style={{ padding: '0.75rem', fontWeight: '500' }}>{wo.number}</td>
+                            <td style={{ padding: '0.75rem' }}>{wo.hullId}</td>
+                            <td style={{ padding: '0.75rem' }}>
                               {wo.routingVersion
-                                ? `${wo.routingVersion.model}${wo.routingVersion.trim ? `-${wo.routingVersion.trim}` : ""}`
+                                ? `${wo.routingVersion.model}${wo.routingVersion.trim ? `-${wo.routingVersion.trim}` : ''}`
                                 : wo.productSku}
                             </td>
-                            <td style={{ padding: "0.75rem" }}>
+                            <td style={{ padding: '0.75rem' }}>
                               <span
                                 style={{
-                                  padding: "0.25rem 0.5rem",
-                                  borderRadius: "4px",
-                                  fontSize: "0.875rem",
+                                  padding: '0.25rem 0.5rem',
+                                  borderRadius: '4px',
+                                  fontSize: '0.875rem',
                                   backgroundColor: priorityColor.bg,
                                   color: priorityColor.text,
-                                  fontWeight: "500",
+                                  fontWeight: '500',
                                 }}
                               >
-                                {wo.priority || "NORMAL"}
+                                {wo.priority || 'NORMAL'}
                               </span>
                             </td>
                             <td
                               style={{
-                                padding: "0.75rem",
-                                fontSize: "0.875rem",
+                                padding: '0.75rem',
+                                fontSize: '0.875rem',
                               }}
                             >
                               {wo.plannedStartDate
-                                ? new Date(
-                                    wo.plannedStartDate,
-                                  ).toLocaleDateString()
-                                : "-"}
+                                ? new Date(wo.plannedStartDate).toLocaleDateString()
+                                : '-'}
                             </td>
                             <td
                               style={{
-                                padding: "0.75rem",
-                                fontSize: "0.875rem",
+                                padding: '0.75rem',
+                                fontSize: '0.875rem',
                               }}
                             >
                               {wo.plannedFinishDate
-                                ? new Date(
-                                    wo.plannedFinishDate,
-                                  ).toLocaleDateString()
-                                : "-"}
+                                ? new Date(wo.plannedFinishDate).toLocaleDateString()
+                                : '-'}
                             </td>
                             <td
                               style={{
-                                padding: "0.75rem",
-                                textAlign: "center",
+                                padding: '0.75rem',
+                                textAlign: 'center',
                               }}
                             >
                               {wo._count && wo._count.attachments > 0 ? (
                                 <span
                                   style={{
-                                    fontSize: "0.875rem",
-                                    backgroundColor:
-                                      "var(--status-info-surface)",
-                                    color: "var(--status-info-foreground)",
-                                    padding: "0.25rem 0.5rem",
-                                    borderRadius: "12px",
-                                    fontWeight: "500",
-                                    display: "inline-flex",
-                                    alignItems: "center",
-                                    gap: "0.25rem",
-                                    position: "relative",
+                                    fontSize: '0.875rem',
+                                    backgroundColor: 'var(--status-info-surface)',
+                                    color: 'var(--status-info-foreground)',
+                                    padding: '0.25rem 0.5rem',
+                                    borderRadius: '12px',
+                                    fontWeight: '500',
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '0.25rem',
+                                    position: 'relative',
                                   }}
                                 >
                                   <span
                                     style={{
                                       border: 0,
-                                      clip: "rect(0, 0, 0, 0)",
-                                      height: "1px",
-                                      margin: "-1px",
-                                      overflow: "hidden",
+                                      clip: 'rect(0, 0, 0, 0)',
+                                      height: '1px',
+                                      margin: '-1px',
+                                      overflow: 'hidden',
                                       padding: 0,
-                                      position: "absolute",
-                                      width: "1px",
-                                      whiteSpace: "nowrap",
+                                      position: 'absolute',
+                                      width: '1px',
+                                      whiteSpace: 'nowrap',
                                     }}
                                   >
                                     {`${wo._count.attachments} attachment${
-                                      wo._count.attachments === 1 ? "" : "s"
+                                      wo._count.attachments === 1 ? '' : 's'
                                     }`}
                                   </span>
                                   <PaperClipIcon
                                     aria-hidden="true"
-                                    style={{ height: "0.75rem", width: "0.75rem" }}
+                                    style={{ height: '0.75rem', width: '0.75rem' }}
                                   />
-                                  <span aria-hidden="true">
-                                    {wo._count.attachments}
-                                  </span>
+                                  <span aria-hidden="true">{wo._count.attachments}</span>
                                 </span>
                               ) : (
                                 <span
                                   style={{
-                                    color: "var(--muted)",
-                                    fontSize: "0.875rem",
+                                    color: 'var(--muted)',
+                                    fontSize: '0.875rem',
                                   }}
                                 >
                                   -
@@ -1939,152 +1840,144 @@ export default function SupervisorView() {
                             </td>
                             <td
                               style={{
-                                padding: "0.75rem",
-                                textAlign: "center",
+                                padding: '0.75rem',
+                                textAlign: 'center',
                               }}
                             >
                               {wo._count && wo._count.notes > 0 ? (
                                 <span
                                   style={{
-                                    fontSize: "0.875rem",
-                                    backgroundColor:
-                                      "var(--status-success-surface)",
-                                    color: "var(--status-success-foreground)",
-                                    padding: "0.25rem 0.5rem",
-                                    borderRadius: "12px",
-                                    fontWeight: "500",
-                                    display: "inline-flex",
-                                    alignItems: "center",
-                                    gap: "0.25rem",
-                                    position: "relative",
+                                    fontSize: '0.875rem',
+                                    backgroundColor: 'var(--status-success-surface)',
+                                    color: 'var(--status-success-foreground)',
+                                    padding: '0.25rem 0.5rem',
+                                    borderRadius: '12px',
+                                    fontWeight: '500',
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '0.25rem',
+                                    position: 'relative',
                                   }}
                                 >
                                   <span
                                     style={{
                                       border: 0,
-                                      clip: "rect(0, 0, 0, 0)",
-                                      height: "1px",
-                                      margin: "-1px",
-                                      overflow: "hidden",
+                                      clip: 'rect(0, 0, 0, 0)',
+                                      height: '1px',
+                                      margin: '-1px',
+                                      overflow: 'hidden',
                                       padding: 0,
-                                      position: "absolute",
-                                      width: "1px",
-                                      whiteSpace: "nowrap",
+                                      position: 'absolute',
+                                      width: '1px',
+                                      whiteSpace: 'nowrap',
                                     }}
                                   >
-                                    {`${wo._count.notes} note${
-                                      wo._count.notes === 1 ? "" : "s"
-                                    }`}
+                                    {`${wo._count.notes} note${wo._count.notes === 1 ? '' : 's'}`}
                                   </span>
                                   <ChatBubbleLeftIcon
                                     aria-hidden="true"
-                                    style={{ height: "0.75rem", width: "0.75rem" }}
+                                    style={{ height: '0.75rem', width: '0.75rem' }}
                                   />
-                                  <span aria-hidden="true">
-                                    {wo._count.notes}
-                                  </span>
+                                  <span aria-hidden="true">{wo._count.notes}</span>
                                 </span>
                               ) : (
                                 <span
                                   style={{
-                                    color: "var(--muted)",
-                                    fontSize: "0.875rem",
+                                    color: 'var(--muted)',
+                                    fontSize: '0.875rem',
                                   }}
                                 >
                                   -
                                 </span>
                               )}
                             </td>
-                            <td style={{ padding: "0.75rem" }}>
+                            <td style={{ padding: '0.75rem' }}>
                               {wo.currentStage ? (
                                 <div>
                                   <div>{wo.currentStage.name}</div>
                                   <div
                                     style={{
-                                      fontSize: "0.875rem",
-                                      color: "var(--muted)",
+                                      fontSize: '0.875rem',
+                                      color: 'var(--muted)',
                                     }}
                                   >
                                     {wo.currentStage.code}
                                   </div>
                                 </div>
                               ) : (
-                                <span style={{ color: "var(--muted)" }}>-</span>
+                                <span style={{ color: 'var(--muted)' }}>-</span>
                               )}
                             </td>
-                            <td style={{ padding: "0.75rem" }}>
+                            <td style={{ padding: '0.75rem' }}>
                               {wo.currentStage?.workCenter?.name
                                 ? `${wo.currentStage.workCenter.name}${
                                     wo.currentStage.department?.name
                                       ? ` (${wo.currentStage.department.name})`
-                                      : ""
+                                      : ''
                                   }`
-                                : "-"}
+                                : '-'}
                             </td>
-                            <td style={{ padding: "0.75rem" }}>
-                              <div style={{ display: "flex", gap: "0.25rem" }}>
+                            <td style={{ padding: '0.75rem' }}>
+                              <div style={{ display: 'flex', gap: '0.25rem' }}>
                                 <button
                                   onClick={() => loadWorkOrderDetails(wo.id)}
                                   style={{
-                                    padding: "0.25rem 0.5rem",
-                                    fontSize: "0.875rem",
-                                    backgroundColor: "var(--color-primary-600)",
-                                    color: "var(--color-primary-foreground)",
-                                    border: "none",
-                                    borderRadius: "3px",
-                                    cursor: "pointer",
+                                    padding: '0.25rem 0.5rem',
+                                    fontSize: '0.875rem',
+                                    backgroundColor: 'var(--color-primary-600)',
+                                    color: 'var(--color-primary-foreground)',
+                                    border: 'none',
+                                    borderRadius: '3px',
+                                    cursor: 'pointer',
                                   }}
                                 >
                                   Open
                                 </button>
-                                {wo.status === "PLANNED" && (
+                                {wo.status === 'PLANNED' && (
                                   <button
                                     onClick={() => releaseWorkOrder(wo.id)}
                                     style={{
-                                      padding: "0.25rem 0.5rem",
-                                      fontSize: "0.875rem",
-                                      backgroundColor:
-                                        "var(--color-success-600)",
-                                      color: "var(--color-primary-foreground)",
-                                      border: "none",
-                                      borderRadius: "3px",
-                                      cursor: "pointer",
+                                      padding: '0.25rem 0.5rem',
+                                      fontSize: '0.875rem',
+                                      backgroundColor: 'var(--color-success-600)',
+                                      color: 'var(--color-primary-foreground)',
+                                      border: 'none',
+                                      borderRadius: '3px',
+                                      cursor: 'pointer',
                                     }}
                                   >
                                     Release
                                   </button>
                                 )}
-                                {wo.status !== "HOLD" &&
-                                  wo.status !== "COMPLETED" &&
-                                  wo.status !== "PLANNED" && (
+                                {wo.status !== 'HOLD' &&
+                                  wo.status !== 'COMPLETED' &&
+                                  wo.status !== 'PLANNED' && (
                                     <button
                                       onClick={() => holdWorkOrder(wo.id)}
                                       style={{
-                                        padding: "0.25rem 0.5rem",
-                                        fontSize: "0.875rem",
-                                        backgroundColor:
-                                          "var(--color-warning-500)",
-                                        color: "var(--foreground)",
-                                        border: "none",
-                                        borderRadius: "3px",
-                                        cursor: "pointer",
+                                        padding: '0.25rem 0.5rem',
+                                        fontSize: '0.875rem',
+                                        backgroundColor: 'var(--color-warning-500)',
+                                        color: 'var(--foreground)',
+                                        border: 'none',
+                                        borderRadius: '3px',
+                                        cursor: 'pointer',
                                       }}
                                     >
                                       Hold
                                     </button>
                                   )}
-                                {wo.status === "HOLD" && (
+                                {wo.status === 'HOLD' && (
                                   <button
                                     onClick={() => unholdWorkOrder(wo.id)}
                                     style={{
-                                      padding: "0.25rem 0.5rem",
-                                      fontSize: "0.875rem",
-                                      backgroundColor:
-                                        "var(--color-success-600)",
-                                      color: "var(--color-primary-foreground)",
-                                      border: "none",
-                                      borderRadius: "3px",
-                                      cursor: "pointer",
+                                      padding: '0.25rem 0.5rem',
+                                      fontSize: '0.875rem',
+                                      backgroundColor: 'var(--color-success-600)',
+                                      color: 'var(--color-primary-foreground)',
+                                      border: 'none',
+                                      borderRadius: '3px',
+                                      cursor: 'pointer',
                                     }}
                                   >
                                     Unhold
@@ -2093,7 +1986,7 @@ export default function SupervisorView() {
                               </div>
                             </td>
                           </tr>
-                        );
+                        )
                       })}
                     </tbody>
                   </table>
@@ -2101,9 +1994,9 @@ export default function SupervisorView() {
                   {workOrders.length === 0 && (
                     <div
                       style={{
-                        padding: "3rem",
-                        textAlign: "center",
-                        color: "var(--muted)",
+                        padding: '3rem',
+                        textAlign: 'center',
+                        color: 'var(--muted)',
                       }}
                     >
                       No work orders found
@@ -2120,143 +2013,133 @@ export default function SupervisorView() {
       {isDetailDrawerOpen && selectedWorkOrder && (
         <div
           style={{
-            position: "fixed",
+            position: 'fixed',
             right: 0,
             top: 0,
             bottom: 0,
-            width: "500px",
-            backgroundColor: "var(--surface)",
-            boxShadow: "-2px 0 8px rgba(0,0,0,0.1)",
+            width: '500px',
+            backgroundColor: 'var(--surface)',
+            boxShadow: '-2px 0 8px rgba(0,0,0,0.1)',
             zIndex: 1000,
-            overflowY: "auto",
+            overflowY: 'auto',
           }}
         >
           <div
             style={{
-              padding: "1.25rem",
-              borderBottom: "1px solid var(--border)",
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
+              padding: '1.25rem',
+              borderBottom: '1px solid var(--border)',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
             }}
           >
-            <h2 style={{ margin: 0, fontSize: "1.25rem", fontWeight: "600" }}>
+            <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: '600' }}>
               Work Order Details
             </h2>
             <button
               onClick={() => {
-                setIsDetailDrawerOpen(false);
-                setSelectedWorkOrder(null);
-                setEditedWorkOrder(null);
-                setHasUnsavedChanges(false);
-                setIsEditingPlanningDetails(false);
-                setActiveDetailTab("details");
+                setIsDetailDrawerOpen(false)
+                setSelectedWorkOrder(null)
+                setEditedWorkOrder(null)
+                setHasUnsavedChanges(false)
+                setIsEditingPlanningDetails(false)
+                setActiveDetailTab('details')
               }}
               style={{
-                padding: "0.25rem 0.5rem",
-                backgroundColor: "transparent",
-                border: "none",
-                cursor: "pointer",
-                fontSize: "1.5rem",
-                color: "var(--muted)",
+                padding: '0.25rem 0.5rem',
+                backgroundColor: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '1.5rem',
+                color: 'var(--muted)',
               }}
             >
               ×
             </button>
           </div>
 
-          <div style={{ padding: "1.25rem" }}>
+          <div style={{ padding: '1.25rem' }}>
             {/* Detail Tabs */}
-            <div style={{ marginBottom: "1rem" }}>
+            <div style={{ marginBottom: '1rem' }}>
               <div
                 style={{
-                  display: "flex",
-                  gap: "0.5rem",
-                  borderBottom: "1px solid var(--border)",
-                  flexWrap: "wrap",
+                  display: 'flex',
+                  gap: '0.5rem',
+                  borderBottom: '1px solid var(--border)',
+                  flexWrap: 'wrap',
                 }}
               >
                 <button
-                  onClick={() => setActiveDetailTab("details")}
+                  onClick={() => setActiveDetailTab('details')}
                   style={{
-                    padding: "0.5rem 1rem",
-                    backgroundColor: "transparent",
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'transparent',
                     color:
-                      activeDetailTab === "details"
-                        ? "var(--color-primary-600)"
-                        : "var(--muted)",
-                    border: "none",
-                    borderBottom: `2px solid ${activeDetailTab === "details" ? "var(--color-primary-600)" : "transparent"}`,
-                    cursor: "pointer",
-                    fontWeight: activeDetailTab === "details" ? "600" : "400",
+                      activeDetailTab === 'details' ? 'var(--color-primary-600)' : 'var(--muted)',
+                    border: 'none',
+                    borderBottom: `2px solid ${activeDetailTab === 'details' ? 'var(--color-primary-600)' : 'transparent'}`,
+                    cursor: 'pointer',
+                    fontWeight: activeDetailTab === 'details' ? '600' : '400',
                   }}
                 >
                   Details
                 </button>
                 <button
-                  onClick={() => setActiveDetailTab("timeline")}
+                  onClick={() => setActiveDetailTab('timeline')}
                   style={{
-                    padding: "0.5rem 1rem",
-                    backgroundColor: "transparent",
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'transparent',
                     color:
-                      activeDetailTab === "timeline"
-                        ? "var(--color-primary-600)"
-                        : "var(--muted)",
-                    border: "none",
-                    borderBottom: `2px solid ${activeDetailTab === "timeline" ? "var(--color-primary-600)" : "transparent"}`,
-                    cursor: "pointer",
-                    fontWeight: activeDetailTab === "timeline" ? "600" : "400",
+                      activeDetailTab === 'timeline' ? 'var(--color-primary-600)' : 'var(--muted)',
+                    border: 'none',
+                    borderBottom: `2px solid ${activeDetailTab === 'timeline' ? 'var(--color-primary-600)' : 'transparent'}`,
+                    cursor: 'pointer',
+                    fontWeight: activeDetailTab === 'timeline' ? '600' : '400',
                   }}
                 >
                   Timeline
                 </button>
                 <button
-                  onClick={() => setActiveDetailTab("notes")}
+                  onClick={() => setActiveDetailTab('notes')}
                   style={{
-                    padding: "0.5rem 1rem",
-                    backgroundColor: "transparent",
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'transparent',
                     color:
-                      activeDetailTab === "notes"
-                        ? "var(--color-primary-600)"
-                        : "var(--muted)",
-                    border: "none",
-                    borderBottom: `2px solid ${activeDetailTab === "notes" ? "var(--color-primary-600)" : "transparent"}`,
-                    cursor: "pointer",
-                    fontWeight: activeDetailTab === "notes" ? "600" : "400",
+                      activeDetailTab === 'notes' ? 'var(--color-primary-600)' : 'var(--muted)',
+                    border: 'none',
+                    borderBottom: `2px solid ${activeDetailTab === 'notes' ? 'var(--color-primary-600)' : 'transparent'}`,
+                    cursor: 'pointer',
+                    fontWeight: activeDetailTab === 'notes' ? '600' : '400',
                   }}
                 >
                   Notes
                 </button>
                 <button
-                  onClick={() => setActiveDetailTab("files")}
+                  onClick={() => setActiveDetailTab('files')}
                   style={{
-                    padding: "0.5rem 1rem",
-                    backgroundColor: "transparent",
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'transparent',
                     color:
-                      activeDetailTab === "files"
-                        ? "var(--color-primary-600)"
-                        : "var(--muted)",
-                    border: "none",
-                    borderBottom: `2px solid ${activeDetailTab === "files" ? "var(--color-primary-600)" : "transparent"}`,
-                    cursor: "pointer",
-                    fontWeight: activeDetailTab === "files" ? "600" : "400",
+                      activeDetailTab === 'files' ? 'var(--color-primary-600)' : 'var(--muted)',
+                    border: 'none',
+                    borderBottom: `2px solid ${activeDetailTab === 'files' ? 'var(--color-primary-600)' : 'transparent'}`,
+                    cursor: 'pointer',
+                    fontWeight: activeDetailTab === 'files' ? '600' : '400',
                   }}
                 >
                   Files
                 </button>
                 <button
-                  onClick={() => setActiveDetailTab("versions")}
+                  onClick={() => setActiveDetailTab('versions')}
                   style={{
-                    padding: "0.5rem 1rem",
-                    backgroundColor: "transparent",
+                    padding: '0.5rem 1rem',
+                    backgroundColor: 'transparent',
                     color:
-                      activeDetailTab === "versions"
-                        ? "var(--color-primary-600)"
-                        : "var(--muted)",
-                    border: "none",
-                    borderBottom: `2px solid ${activeDetailTab === "versions" ? "var(--color-primary-600)" : "transparent"}`,
-                    cursor: "pointer",
-                    fontWeight: activeDetailTab === "versions" ? "600" : "400",
+                      activeDetailTab === 'versions' ? 'var(--color-primary-600)' : 'var(--muted)',
+                    border: 'none',
+                    borderBottom: `2px solid ${activeDetailTab === 'versions' ? 'var(--color-primary-600)' : 'transparent'}`,
+                    cursor: 'pointer',
+                    fontWeight: activeDetailTab === 'versions' ? '600' : '400',
                   }}
                 >
                   Versions
@@ -2265,24 +2148,24 @@ export default function SupervisorView() {
             </div>
 
             {/* Tab Content */}
-            {activeDetailTab === "details" && editedWorkOrder && (
+            {activeDetailTab === 'details' && editedWorkOrder && (
               <div>
                 {/* Read-only Info */}
-                <div style={{ marginBottom: "1.5rem" }}>
+                <div style={{ marginBottom: '1.5rem' }}>
                   <h3
                     style={{
-                      margin: "0 0 1rem 0",
-                      fontSize: "1.1rem",
-                      fontWeight: "600",
+                      margin: '0 0 1rem 0',
+                      fontSize: '1.1rem',
+                      fontWeight: '600',
                     }}
                   >
                     Basic Information
                   </h3>
                   <div
                     style={{
-                      display: "grid",
-                      gap: "0.5rem",
-                      marginBottom: "1rem",
+                      display: 'grid',
+                      gap: '0.5rem',
+                      marginBottom: '1rem',
                     }}
                   >
                     <div>
@@ -2298,11 +2181,11 @@ export default function SupervisorView() {
                       <strong>Quantity:</strong> {selectedWorkOrder.qty}
                     </div>
                     <div>
-                      <strong>Status:</strong>{" "}
+                      <strong>Status:</strong>{' '}
                       <span
                         style={{
-                          padding: "0.25rem 0.5rem",
-                          borderRadius: "4px",
+                          padding: '0.25rem 0.5rem',
+                          borderRadius: '4px',
                           ...getStatusColor(selectedWorkOrder.status),
                         }}
                       >
@@ -2310,50 +2193,48 @@ export default function SupervisorView() {
                       </span>
                     </div>
                     <div>
-                      <strong>Created:</strong>{" "}
+                      <strong>Created:</strong>{' '}
                       {new Date(selectedWorkOrder.createdAt).toLocaleString()}
                     </div>
                   </div>
                 </div>
 
-                <div style={{ marginBottom: "1.5rem" }}>
+                <div style={{ marginBottom: '1.5rem' }}>
                   <div
                     style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      gap: "0.75rem",
-                      marginBottom: "1rem",
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      gap: '0.75rem',
+                      marginBottom: '1rem',
                     }}
                   >
                     <h3
                       style={{
                         margin: 0,
-                        fontSize: "1.1rem",
-                        fontWeight: "600",
+                        fontSize: '1.1rem',
+                        fontWeight: '600',
                       }}
                     >
                       Planning Details
                     </h3>
                     {selectedWorkOrder &&
-                      (userRole === "SUPERVISOR" || userRole === "ADMIN") &&
+                      (userRole === 'SUPERVISOR' || userRole === 'ADMIN') &&
                       !isEditingPlanningDetails &&
-                      !["COMPLETED", "CLOSED"].includes(
-                        selectedWorkOrder.status,
-                      ) && (
+                      !['COMPLETED', 'CLOSED'].includes(selectedWorkOrder.status) && (
                         <button
                           onClick={() => {
-                            discardWorkOrderChanges();
-                            setIsEditingPlanningDetails(true);
+                            discardWorkOrderChanges()
+                            setIsEditingPlanningDetails(true)
                           }}
                           style={{
-                            padding: "0.4rem 0.9rem",
-                            backgroundColor: "var(--table-header-surface)",
-                            color: "var(--foreground)",
-                            border: "1px solid var(--border)",
-                            borderRadius: "4px",
-                            cursor: "pointer",
-                            fontWeight: "500",
+                            padding: '0.4rem 0.9rem',
+                            backgroundColor: 'var(--table-header-surface)',
+                            color: 'var(--foreground)',
+                            border: '1px solid var(--border)',
+                            borderRadius: '4px',
+                            cursor: 'pointer',
+                            fontWeight: '500',
                           }}
                         >
                           Edit
@@ -2363,13 +2244,13 @@ export default function SupervisorView() {
 
                   {isEditingPlanningDetails ? (
                     <>
-                      <div style={{ display: "grid", gap: "1rem" }}>
+                      <div style={{ display: 'grid', gap: '1rem' }}>
                         <div>
                           <label
                             style={{
-                              display: "block",
-                              marginBottom: "0.25rem",
-                              fontWeight: "500",
+                              display: 'block',
+                              marginBottom: '0.25rem',
+                              fontWeight: '500',
                             }}
                           >
                             Priority
@@ -2380,14 +2261,14 @@ export default function SupervisorView() {
                               setEditedWorkOrder({
                                 ...editedWorkOrder,
                                 priority: e.target.value,
-                              });
-                              setHasUnsavedChanges(true);
+                              })
+                              setHasUnsavedChanges(true)
                             }}
                             style={{
-                              width: "100%",
-                              padding: "0.5rem",
-                              border: "1px solid var(--border)",
-                              borderRadius: "4px",
+                              width: '100%',
+                              padding: '0.5rem',
+                              border: '1px solid var(--border)',
+                              borderRadius: '4px',
                             }}
                           >
                             <option value="LOW">Low</option>
@@ -2400,9 +2281,9 @@ export default function SupervisorView() {
                         <div>
                           <label
                             style={{
-                              display: "block",
-                              marginBottom: "0.25rem",
-                              fontWeight: "500",
+                              display: 'block',
+                              marginBottom: '0.25rem',
+                              fontWeight: '500',
                             }}
                           >
                             Planned Start Date
@@ -2414,14 +2295,14 @@ export default function SupervisorView() {
                               setEditedWorkOrder({
                                 ...editedWorkOrder,
                                 plannedStartDate: e.target.value,
-                              });
-                              setHasUnsavedChanges(true);
+                              })
+                              setHasUnsavedChanges(true)
                             }}
                             style={{
-                              width: "100%",
-                              padding: "0.5rem",
-                              border: "1px solid var(--border)",
-                              borderRadius: "4px",
+                              width: '100%',
+                              padding: '0.5rem',
+                              border: '1px solid var(--border)',
+                              borderRadius: '4px',
                             }}
                           />
                         </div>
@@ -2429,9 +2310,9 @@ export default function SupervisorView() {
                         <div>
                           <label
                             style={{
-                              display: "block",
-                              marginBottom: "0.25rem",
-                              fontWeight: "500",
+                              display: 'block',
+                              marginBottom: '0.25rem',
+                              fontWeight: '500',
                             }}
                           >
                             Planned Finish Date
@@ -2443,14 +2324,14 @@ export default function SupervisorView() {
                               setEditedWorkOrder({
                                 ...editedWorkOrder,
                                 plannedFinishDate: e.target.value,
-                              });
-                              setHasUnsavedChanges(true);
+                              })
+                              setHasUnsavedChanges(true)
                             }}
                             style={{
-                              width: "100%",
-                              padding: "0.5rem",
-                              border: "1px solid var(--border)",
-                              borderRadius: "4px",
+                              width: '100%',
+                              padding: '0.5rem',
+                              border: '1px solid var(--border)',
+                              borderRadius: '4px',
                             }}
                           />
                         </div>
@@ -2458,26 +2339,24 @@ export default function SupervisorView() {
 
                       <div
                         style={{
-                          display: "flex",
-                          gap: "0.75rem",
-                          marginTop: "1rem",
+                          display: 'flex',
+                          gap: '0.75rem',
+                          marginTop: '1rem',
                         }}
                       >
                         <button
                           onClick={saveWorkOrderChanges}
                           disabled={!hasUnsavedChanges}
                           style={{
-                            padding: "0.5rem 1rem",
+                            padding: '0.5rem 1rem',
                             backgroundColor: hasUnsavedChanges
-                              ? "var(--color-primary-600)"
-                              : "var(--muted)",
-                            color: "var(--color-primary-foreground)",
-                            border: "none",
-                            borderRadius: "4px",
-                            cursor: hasUnsavedChanges
-                              ? "pointer"
-                              : "not-allowed",
-                            fontWeight: "500",
+                              ? 'var(--color-primary-600)'
+                              : 'var(--muted)',
+                            color: 'var(--color-primary-foreground)',
+                            border: 'none',
+                            borderRadius: '4px',
+                            cursor: hasUnsavedChanges ? 'pointer' : 'not-allowed',
+                            fontWeight: '500',
                             opacity: hasUnsavedChanges ? 1 : 0.7,
                           }}
                         >
@@ -2485,17 +2364,17 @@ export default function SupervisorView() {
                         </button>
                         <button
                           onClick={() => {
-                            discardWorkOrderChanges();
-                            setIsEditingPlanningDetails(false);
+                            discardWorkOrderChanges()
+                            setIsEditingPlanningDetails(false)
                           }}
                           style={{
-                            padding: "0.5rem 1rem",
-                            backgroundColor: "var(--table-header-surface)",
-                            color: "var(--foreground)",
-                            border: "1px solid var(--border)",
-                            borderRadius: "4px",
-                            cursor: "pointer",
-                            fontWeight: "500",
+                            padding: '0.5rem 1rem',
+                            backgroundColor: 'var(--table-header-surface)',
+                            color: 'var(--foreground)',
+                            border: '1px solid var(--border)',
+                            borderRadius: '4px',
+                            cursor: 'pointer',
+                            fontWeight: '500',
                           }}
                         >
                           Cancel
@@ -2503,57 +2382,52 @@ export default function SupervisorView() {
                       </div>
                     </>
                   ) : (
-                    <div style={{ display: "grid", gap: "0.5rem" }}>
+                    <div style={{ display: 'grid', gap: '0.5rem' }}>
                       <div>
-                        <strong>Priority:</strong>{" "}
-                        {selectedWorkOrder.priority || "NORMAL"}
+                        <strong>Priority:</strong> {selectedWorkOrder.priority || 'NORMAL'}
                       </div>
                       <div>
-                        <strong>Planned Start:</strong>{" "}
+                        <strong>Planned Start:</strong>{' '}
                         {selectedWorkOrder.plannedStartDate
-                          ? new Date(
-                              selectedWorkOrder.plannedStartDate,
-                            ).toLocaleString()
-                          : "Not set"}
+                          ? new Date(selectedWorkOrder.plannedStartDate).toLocaleString()
+                          : 'Not set'}
                       </div>
                       <div>
-                        <strong>Planned Finish:</strong>{" "}
+                        <strong>Planned Finish:</strong>{' '}
                         {selectedWorkOrder.plannedFinishDate
-                          ? new Date(
-                              selectedWorkOrder.plannedFinishDate,
-                            ).toLocaleString()
-                          : "Not set"}
+                          ? new Date(selectedWorkOrder.plannedFinishDate).toLocaleString()
+                          : 'Not set'}
                       </div>
                     </div>
                   )}
                 </div>
 
-                {selectedWorkOrder.status !== "CANCELLED" && (
+                {selectedWorkOrder.status !== 'CANCELLED' && (
                   <div
                     style={{
-                      marginTop: "1rem",
-                      paddingTop: "1rem",
-                      borderTop: "1px solid var(--border)",
+                      marginTop: '1rem',
+                      paddingTop: '1rem',
+                      borderTop: '1px solid var(--border)',
                     }}
                   >
                     <button
                       onClick={() => {
                         if (
                           confirm(
-                            "Are you sure you want to cancel this work order? This action creates a version snapshot.",
+                            'Are you sure you want to cancel this work order? This action creates a version snapshot.'
                           )
                         ) {
-                          cancelWorkOrder(selectedWorkOrder.id);
+                          cancelWorkOrder(selectedWorkOrder.id)
                         }
                       }}
                       style={{
-                        padding: "0.5rem 1rem",
-                        backgroundColor: "var(--color-danger-600)",
-                        color: "var(--color-primary-foreground)",
-                        border: "none",
-                        borderRadius: "4px",
-                        cursor: "pointer",
-                        fontWeight: "500",
+                        padding: '0.5rem 1rem',
+                        backgroundColor: 'var(--color-danger-600)',
+                        color: 'var(--color-primary-foreground)',
+                        border: 'none',
+                        borderRadius: '4px',
+                        cursor: 'pointer',
+                        fontWeight: '500',
                       }}
                     >
                       Cancel Work Order
@@ -2563,17 +2437,16 @@ export default function SupervisorView() {
               </div>
             )}
 
-            {activeDetailTab === "timeline" && (
+            {activeDetailTab === 'timeline' && (
               <div>
                 {/* Stage Timeline */}
-                {selectedWorkOrder.stageTimeline &&
-                selectedWorkOrder.stageTimeline.length > 0 ? (
+                {selectedWorkOrder.stageTimeline && selectedWorkOrder.stageTimeline.length > 0 ? (
                   <div>
                     <h3
                       style={{
-                        margin: "0 0 1rem 0",
-                        fontSize: "1.1rem",
-                        fontWeight: "600",
+                        margin: '0 0 1rem 0',
+                        fontSize: '1.1rem',
+                        fontWeight: '600',
                       }}
                     >
                       Stage Timeline
@@ -2582,60 +2455,56 @@ export default function SupervisorView() {
                       <div
                         key={stage.stageId}
                         style={{
-                          padding: "0.75rem",
-                          marginBottom: "0.5rem",
-                          backgroundColor: "var(--table-header-surface)",
-                          borderRadius: "4px",
-                          border: "1px solid var(--border)",
+                          padding: '0.75rem',
+                          marginBottom: '0.5rem',
+                          backgroundColor: 'var(--table-header-surface)',
+                          borderRadius: '4px',
+                          border: '1px solid var(--border)',
                         }}
                       >
-                        <div
-                          style={{ fontWeight: "500", marginBottom: "0.5rem" }}
-                        >
+                        <div style={{ fontWeight: '500', marginBottom: '0.5rem' }}>
                           {stage.stageName} ({stage.stageCode})
                         </div>
                         {stage.events.map((event: any) => (
                           <div
                             key={event.id}
                             style={{
-                              padding: "0.5rem",
-                              marginBottom: "0.25rem",
-                              backgroundColor: "var(--surface)",
-                              borderRadius: "3px",
-                              fontSize: "0.875rem",
+                              padding: '0.5rem',
+                              marginBottom: '0.25rem',
+                              backgroundColor: 'var(--surface)',
+                              borderRadius: '3px',
+                              fontSize: '0.875rem',
                             }}
                           >
                             <div
                               style={{
-                                display: "flex",
-                                justifyContent: "space-between",
+                                display: 'flex',
+                                justifyContent: 'space-between',
                               }}
                             >
-                              <span style={{ fontWeight: "500" }}>
-                                {event.event}
-                              </span>
-                              <span style={{ color: "var(--muted)" }}>
+                              <span style={{ fontWeight: '500' }}>{event.event}</span>
+                              <span style={{ color: 'var(--muted)' }}>
                                 {new Date(event.createdAt).toLocaleString()}
                               </span>
                             </div>
                             <div
                               style={{
-                                color: "var(--muted)",
-                                marginTop: "0.25rem",
+                                color: 'var(--muted)',
+                                marginTop: '0.25rem',
                               }}
                             >
                               Station: {event.station} • User: {event.user}
                             </div>
-                            {event.event === "COMPLETE" && (
-                              <div style={{ marginTop: "0.25rem" }}>
+                            {event.event === 'COMPLETE' && (
+                              <div style={{ marginTop: '0.25rem' }}>
                                 Good: {event.goodQty} • Scrap: {event.scrapQty}
                               </div>
                             )}
                             {event.note && (
                               <div
                                 style={{
-                                  marginTop: "0.25rem",
-                                  fontStyle: "italic",
+                                  marginTop: '0.25rem',
+                                  fontStyle: 'italic',
                                 }}
                               >
                                 Note: {event.note}
@@ -2649,9 +2518,9 @@ export default function SupervisorView() {
                 ) : (
                   <div
                     style={{
-                      textAlign: "center",
-                      padding: "2rem",
-                      color: "var(--muted)",
+                      textAlign: 'center',
+                      padding: '2rem',
+                      color: 'var(--muted)',
                     }}
                   >
                     No timeline events yet.
@@ -2660,35 +2529,35 @@ export default function SupervisorView() {
               </div>
             )}
 
-            {activeDetailTab === "notes" && (
+            {activeDetailTab === 'notes' && (
               <NotesTimeline
                 workOrderId={selectedWorkOrder.id}
                 onError={(error) => setError(error)}
                 onSuccess={(message) => {
-                  setMessage(message);
-                  setTimeout(() => setMessage(""), 3000);
+                  setMessage(message)
+                  setTimeout(() => setMessage(''), 3000)
                 }}
               />
             )}
 
-            {activeDetailTab === "files" && (
+            {activeDetailTab === 'files' && (
               <FileManager
                 workOrderId={selectedWorkOrder.id}
                 onError={(error) => setError(error)}
                 onSuccess={(message) => {
-                  setMessage(message);
-                  setTimeout(() => setMessage(""), 3000);
+                  setMessage(message)
+                  setTimeout(() => setMessage(''), 3000)
                 }}
               />
             )}
 
-            {activeDetailTab === "versions" && (
+            {activeDetailTab === 'versions' && (
               <div>
                 <h3
                   style={{
-                    margin: "0 0 1rem 0",
-                    fontSize: "1.1rem",
-                    fontWeight: "600",
+                    margin: '0 0 1rem 0',
+                    fontSize: '1.1rem',
+                    fontWeight: '600',
                   }}
                 >
                   Version History
@@ -2699,40 +2568,38 @@ export default function SupervisorView() {
                       <div
                         key={version.id}
                         style={{
-                          padding: "1rem",
-                          marginBottom: "0.75rem",
-                          backgroundColor: "var(--table-header-surface)",
-                          borderRadius: "4px",
-                          border: "1px solid var(--border)",
+                          padding: '1rem',
+                          marginBottom: '0.75rem',
+                          backgroundColor: 'var(--table-header-surface)',
+                          borderRadius: '4px',
+                          border: '1px solid var(--border)',
                         }}
                       >
                         <div
                           style={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "start",
-                            marginBottom: "0.5rem",
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'start',
+                            marginBottom: '0.5rem',
                           }}
                         >
                           <div>
-                            <div
-                              style={{ fontWeight: "600", fontSize: "1rem" }}
-                            >
+                            <div style={{ fontWeight: '600', fontSize: '1rem' }}>
                               Version {version.versionNumber}
                             </div>
                             <div
                               style={{
-                                fontSize: "0.875rem",
-                                color: "var(--muted)",
-                                marginTop: "0.25rem",
+                                fontSize: '0.875rem',
+                                color: 'var(--muted)',
+                                marginTop: '0.25rem',
                               }}
                             >
                               {new Date(version.createdAt).toLocaleString()}
                             </div>
                             <div
                               style={{
-                                fontSize: "0.875rem",
-                                color: "var(--muted)",
+                                fontSize: '0.875rem',
+                                color: 'var(--muted)',
                               }}
                             >
                               By: {version.createdBy}
@@ -2742,33 +2609,33 @@ export default function SupervisorView() {
                         {version.reason && (
                           <div
                             style={{
-                              marginTop: "0.5rem",
-                              fontStyle: "italic",
-                              color: "var(--muted-strong)",
+                              marginTop: '0.5rem',
+                              fontStyle: 'italic',
+                              color: 'var(--muted-strong)',
                             }}
                           >
                             Reason: {version.reason}
                           </div>
                         )}
-                        <details style={{ marginTop: "0.75rem" }}>
+                        <details style={{ marginTop: '0.75rem' }}>
                           <summary
                             style={{
-                              cursor: "pointer",
-                              fontWeight: "500",
-                              color: "var(--color-primary-600)",
+                              cursor: 'pointer',
+                              fontWeight: '500',
+                              color: 'var(--color-primary-600)',
                             }}
                           >
                             View Snapshot
                           </summary>
                           <pre
                             style={{
-                              marginTop: "0.5rem",
-                              padding: "0.75rem",
-                              backgroundColor: "var(--surface)",
-                              borderRadius: "4px",
-                              fontSize: "0.75rem",
-                              overflow: "auto",
-                              maxHeight: "300px",
+                              marginTop: '0.5rem',
+                              padding: '0.75rem',
+                              backgroundColor: 'var(--surface)',
+                              borderRadius: '4px',
+                              fontSize: '0.75rem',
+                              overflow: 'auto',
+                              maxHeight: '300px',
                             }}
                           >
                             {JSON.stringify(version.snapshotData, null, 2)}
@@ -2780,9 +2647,9 @@ export default function SupervisorView() {
                 ) : (
                   <div
                     style={{
-                      textAlign: "center",
-                      padding: "2rem",
-                      color: "var(--muted)",
+                      textAlign: 'center',
+                      padding: '2rem',
+                      color: 'var(--muted)',
                     }}
                   >
                     No version history available.
@@ -2798,71 +2665,70 @@ export default function SupervisorView() {
       {isCreateModalOpen && (
         <div
           style={{
-            position: "fixed",
+            position: 'fixed',
             top: 0,
             left: 0,
             right: 0,
             bottom: 0,
-            backgroundColor: "rgba(0,0,0,0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
             zIndex: 1100,
           }}
         >
           <div
             style={{
-              backgroundColor: "var(--surface)",
-              borderRadius: "8px",
-              width: "90%",
-              maxWidth: "800px",
-              maxHeight: "90vh",
-              overflowY: "auto",
-              padding: "1.5rem",
+              backgroundColor: 'var(--surface)',
+              borderRadius: '8px',
+              width: '90%',
+              maxWidth: '800px',
+              maxHeight: '90vh',
+              overflowY: 'auto',
+              padding: '1.5rem',
             }}
           >
             <div
               style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                marginBottom: "1.5rem",
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '1.5rem',
               }}
             >
-              <h2 style={{ margin: 0, fontSize: "1.25rem", fontWeight: "600" }}>
+              <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: '600' }}>
                 Create Work Order
               </h2>
               <button
                 onClick={() => {
-                  setIsCreateModalOpen(false);
+                  setIsCreateModalOpen(false)
                   setNewWO({
-                    number: "",
-                    hullId: "",
-                    productSku: "",
+                    number: '',
+                    hullId: '',
+                    productSku: '',
                     qty: 1,
-                    model: "",
-                    trim: "",
-                    features: "",
-                    priority: "NORMAL",
-                    plannedStartDate: "",
-                    plannedFinishDate: "",
-                  });
-                  setSelectedModelId("");
-                  setSelectedTrimId("");
-                  setSelectedYear(new Date().getFullYear());
-                  setGeneratedSku("");
-                  setSelectedRoutingVersion(null);
-                  setEditableStages([]);
-                  setRoutingMode("default");
-                  setAvailableRoutingVersions([]);
+                    model: '',
+                    trim: '',
+                    features: '',
+                    priority: 'NORMAL',
+                    ...buildDefaultPlannedWindow(),
+                  })
+                  setSelectedModelId('')
+                  setSelectedTrimId('')
+                  setSelectedYear(new Date().getFullYear())
+                  setGeneratedSku('')
+                  setSelectedRoutingVersion(null)
+                  setEditableStages([])
+                  setRoutingMode('default')
+                  setAvailableRoutingVersions([])
                 }}
                 style={{
-                  padding: "0.25rem 0.5rem",
-                  backgroundColor: "transparent",
-                  border: "none",
-                  cursor: "pointer",
-                  fontSize: "1.5rem",
-                  color: "var(--muted)",
+                  padding: '0.25rem 0.5rem',
+                  backgroundColor: 'transparent',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: '1.5rem',
+                  color: 'var(--muted)',
                 }}
               >
                 ×
@@ -2872,18 +2738,18 @@ export default function SupervisorView() {
             {/* Work Order Fields */}
             <div
               style={{
-                display: "grid",
-                gridTemplateColumns: "1fr 1fr",
-                gap: "1rem",
-                marginBottom: "1.5rem",
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: '1rem',
+                marginBottom: '1.5rem',
               }}
             >
               <div>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   WO Number (optional)
@@ -2891,15 +2757,13 @@ export default function SupervisorView() {
                 <input
                   type="text"
                   value={newWO.number}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, number: e.target.value })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, number: e.target.value })}
                   placeholder="Auto-generated if blank"
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
                   }}
                 />
               </div>
@@ -2907,9 +2771,9 @@ export default function SupervisorView() {
               <div>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Hull ID *
@@ -2917,15 +2781,13 @@ export default function SupervisorView() {
                 <input
                   type="text"
                   value={newWO.hullId}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, hullId: e.target.value })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, hullId: e.target.value })}
                   placeholder="e.g., HULL-2024-001"
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
                   }}
                 />
               </div>
@@ -2933,9 +2795,9 @@ export default function SupervisorView() {
               <div>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Quantity
@@ -2943,15 +2805,13 @@ export default function SupervisorView() {
                 <input
                   type="number"
                   value={newWO.qty}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, qty: parseInt(e.target.value) || 1 })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, qty: parseInt(e.target.value) || 1 })}
                   min="1"
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
                   }}
                 />
               </div>
@@ -2959,23 +2819,21 @@ export default function SupervisorView() {
               <div>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Priority
                 </label>
                 <select
                   value={newWO.priority}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, priority: e.target.value as any })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, priority: e.target.value as any })}
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
                   }}
                 >
                   <option value="LOW">Low</option>
@@ -2988,9 +2846,9 @@ export default function SupervisorView() {
               <div>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Planned Start Date
@@ -2998,14 +2856,12 @@ export default function SupervisorView() {
                 <input
                   type="datetime-local"
                   value={newWO.plannedStartDate}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, plannedStartDate: e.target.value })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, plannedStartDate: e.target.value })}
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
                   }}
                 />
               </div>
@@ -3013,9 +2869,9 @@ export default function SupervisorView() {
               <div>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Planned Finish Date
@@ -3023,26 +2879,24 @@ export default function SupervisorView() {
                 <input
                   type="datetime-local"
                   value={newWO.plannedFinishDate}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, plannedFinishDate: e.target.value })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, plannedFinishDate: e.target.value })}
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
                   }}
                 />
               </div>
             </div>
 
             {/* Model/Trim Selection */}
-            <div style={{ marginBottom: "1.5rem" }}>
+            <div style={{ marginBottom: '1.5rem' }}>
               <h3
                 style={{
-                  margin: "0 0 1rem 0",
-                  fontSize: "1.1rem",
-                  fontWeight: "600",
+                  margin: '0 0 1rem 0',
+                  fontSize: '1.1rem',
+                  fontWeight: '600',
                 }}
               >
                 Product Configuration
@@ -3052,19 +2906,19 @@ export default function SupervisorView() {
                 selectedTrimId={selectedTrimId}
                 year={selectedYear}
                 onModelChange={(modelId, model) => {
-                  setSelectedModelId(modelId);
-                  setNewWO({ ...newWO, model: model?.name || "" });
+                  setSelectedModelId(modelId)
+                  setNewWO({ ...newWO, model: model?.name || '' })
                 }}
                 onTrimChange={(trimId, trim) => {
-                  setSelectedTrimId(trimId);
-                  setNewWO({ ...newWO, trim: trim?.name || "" });
+                  setSelectedTrimId(trimId)
+                  setNewWO({ ...newWO, trim: trim?.name || '' })
                 }}
                 onYearChange={(year) => {
-                  setSelectedYear(year);
+                  setSelectedYear(year)
                 }}
                 onSkuGenerated={(sku) => {
-                  setGeneratedSku(sku);
-                  setNewWO({ ...newWO, productSku: sku });
+                  setGeneratedSku(sku)
+                  setNewWO({ ...newWO, productSku: sku })
                 }}
                 onError={(error) => setError(error)}
               />
@@ -3072,105 +2926,99 @@ export default function SupervisorView() {
 
             <div
               style={{
-                display: "grid",
-                gridTemplateColumns: "1fr",
-                gap: "1rem",
-                marginBottom: "1.5rem",
+                display: 'grid',
+                gridTemplateColumns: '1fr',
+                gap: '1rem',
+                marginBottom: '1.5rem',
               }}
             >
-              <div style={{ gridColumn: "1 / -1" }}>
+              <div style={{ gridColumn: '1 / -1' }}>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Features (JSON)
                 </label>
                 <textarea
                   value={newWO.features}
-                  onChange={(e) =>
-                    setNewWO({ ...newWO, features: e.target.value })
-                  }
+                  onChange={(e) => setNewWO({ ...newWO, features: e.target.value })}
                   placeholder='{"color": "blue", "engine": "V8"}'
                   rows={3}
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
-                    fontFamily: "monospace",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
+                    fontFamily: 'monospace',
                   }}
                 />
               </div>
             </div>
 
             {/* Routing Configuration */}
-            <div style={{ marginBottom: "1.5rem" }}>
+            <div style={{ marginBottom: '1.5rem' }}>
               <h3
                 style={{
-                  margin: "0 0 1rem 0",
-                  fontSize: "1.1rem",
-                  fontWeight: "600",
+                  margin: '0 0 1rem 0',
+                  fontSize: '1.1rem',
+                  fontWeight: '600',
                 }}
               >
                 Routing Configuration
               </h3>
 
               {/* Routing Configuration Dropdown */}
-              <div style={{ marginBottom: "1rem" }}>
+              <div style={{ marginBottom: '1rem' }}>
                 <label
                   style={{
-                    display: "block",
-                    marginBottom: "0.25rem",
-                    fontWeight: "500",
+                    display: 'block',
+                    marginBottom: '0.25rem',
+                    fontWeight: '500',
                   }}
                 >
                   Routing Configuration
                 </label>
                 <select
                   value={
-                    routingMode === "existing"
+                    routingMode === 'existing'
                       ? `existing_${selectedRoutingVersion?.id}`
                       : routingMode
                   }
                   onChange={(e) => {
-                    const value = e.target.value;
-                    if (value.startsWith("existing_")) {
-                      const routingVersionId = value.replace("existing_", "");
-                      handleRoutingModeChange("existing", routingVersionId);
+                    const value = e.target.value
+                    if (value.startsWith('existing_')) {
+                      const routingVersionId = value.replace('existing_', '')
+                      handleRoutingModeChange('existing', routingVersionId)
                     } else {
-                      handleRoutingModeChange(
-                        value as "default" | "create_new",
-                      );
+                      handleRoutingModeChange(value as 'default' | 'create_new')
                     }
                   }}
                   style={{
-                    width: "100%",
-                    padding: "0.5rem",
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
-                    fontSize: "0.875rem",
+                    width: '100%',
+                    padding: '0.5rem',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
+                    fontSize: '0.875rem',
                   }}
                 >
-                  <option value="default">
-                    Default Routing (All Departments)
-                  </option>
+                  <option value="default">Default Routing (All Departments)</option>
                   <option value="create_new">Create New Routing</option>
                   {availableRoutingVersions.map((rv) => (
                     <option key={rv.id} value={`existing_${rv.id}`}>
                       {rv.model}
-                      {rv.trim ? `-${rv.trim}` : ""} v{rv.version} ({rv.status})
+                      {rv.trim ? `-${rv.trim}` : ''} v{rv.version} ({rv.status})
                     </option>
                   ))}
                 </select>
                 {loadingRoutings && (
                   <div
                     style={{
-                      fontSize: "0.75rem",
-                      color: "var(--muted)",
-                      marginTop: "0.25rem",
+                      fontSize: '0.75rem',
+                      color: 'var(--muted)',
+                      marginTop: '0.25rem',
                     }}
                   >
                     Loading routing configurations...
@@ -3180,22 +3028,22 @@ export default function SupervisorView() {
 
               {/* Save Routing Button */}
               {editableStages.length > 0 && (
-                <div style={{ marginBottom: "1rem" }}>
+                <div style={{ marginBottom: '1rem' }}>
                   <button
                     onClick={saveCurrentRouting}
                     style={{
-                      padding: "0.5rem 1rem",
-                      backgroundColor: "var(--color-success-600)",
-                      color: "var(--color-primary-foreground)",
-                      border: "none",
-                      borderRadius: "4px",
-                      cursor: "pointer",
-                      marginRight: "0.5rem",
+                      padding: '0.5rem 1rem',
+                      backgroundColor: 'var(--color-success-600)',
+                      color: 'var(--color-primary-foreground)',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      marginRight: '0.5rem',
                     }}
                   >
                     Save New Routing
                   </button>
-                  <span style={{ fontSize: "0.75rem", color: "var(--muted)" }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--muted)' }}>
                     Save current configuration for reuse
                   </span>
                 </div>
@@ -3204,16 +3052,16 @@ export default function SupervisorView() {
               {editableStages.length > 0 && (
                 <div
                   style={{
-                    border: "1px solid var(--border)",
-                    borderRadius: "4px",
-                    padding: "1rem",
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
+                    padding: '1rem',
                   }}
                 >
                   <h4
                     style={{
-                      margin: "0 0 1rem 0",
-                      fontSize: "1rem",
-                      fontWeight: "500",
+                      margin: '0 0 1rem 0',
+                      fontSize: '1rem',
+                      fontWeight: '500',
                     }}
                   >
                     Configure Stages
@@ -3222,21 +3070,21 @@ export default function SupervisorView() {
                     <div
                       key={index}
                       style={{
-                        padding: "0.75rem",
-                        marginBottom: "0.5rem",
+                        padding: '0.75rem',
+                        marginBottom: '0.5rem',
                         backgroundColor: stage.enabled
-                          ? "var(--table-header-surface)"
-                          : "var(--status-warning-surface)",
-                        borderRadius: "4px",
-                        border: "1px solid var(--border)",
+                          ? 'var(--table-header-surface)'
+                          : 'var(--status-warning-surface)',
+                        borderRadius: '4px',
+                        border: '1px solid var(--border)',
                       }}
                     >
                       <div
                         style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "1rem",
-                          marginBottom: "0.5rem",
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '1rem',
+                          marginBottom: '0.5rem',
                         }}
                       >
                         <input
@@ -3249,25 +3097,23 @@ export default function SupervisorView() {
                         </strong>
                         <div
                           style={{
-                            marginLeft: "auto",
-                            display: "flex",
-                            gap: "0.25rem",
+                            marginLeft: 'auto',
+                            display: 'flex',
+                            gap: '0.25rem',
                           }}
                         >
                           <button
                             onClick={() => moveStageUp(index)}
                             disabled={index === 0}
                             style={{
-                              padding: "0.25rem 0.5rem",
-                              fontSize: "0.75rem",
+                              padding: '0.25rem 0.5rem',
+                              fontSize: '0.75rem',
                               backgroundColor:
-                                index === 0
-                                  ? "var(--muted)"
-                                  : "var(--color-primary-600)",
-                              color: "var(--color-primary-foreground)",
-                              border: "none",
-                              borderRadius: "3px",
-                              cursor: index === 0 ? "not-allowed" : "pointer",
+                                index === 0 ? 'var(--muted)' : 'var(--color-primary-600)',
+                              color: 'var(--color-primary-foreground)',
+                              border: 'none',
+                              borderRadius: '3px',
+                              cursor: index === 0 ? 'not-allowed' : 'pointer',
                               opacity: index === 0 ? 0.5 : 1,
                             }}
                           >
@@ -3277,21 +3123,18 @@ export default function SupervisorView() {
                             onClick={() => moveStageDown(index)}
                             disabled={index === editableStages.length - 1}
                             style={{
-                              padding: "0.25rem 0.5rem",
-                              fontSize: "0.75rem",
+                              padding: '0.25rem 0.5rem',
+                              fontSize: '0.75rem',
                               backgroundColor:
                                 index === editableStages.length - 1
-                                  ? "var(--muted)"
-                                  : "var(--color-primary-600)",
-                              color: "var(--color-primary-foreground)",
-                              border: "none",
-                              borderRadius: "3px",
+                                  ? 'var(--muted)'
+                                  : 'var(--color-primary-600)',
+                              color: 'var(--color-primary-foreground)',
+                              border: 'none',
+                              borderRadius: '3px',
                               cursor:
-                                index === editableStages.length - 1
-                                  ? "not-allowed"
-                                  : "pointer",
-                              opacity:
-                                index === editableStages.length - 1 ? 0.5 : 1,
+                                index === editableStages.length - 1 ? 'not-allowed' : 'pointer',
+                              opacity: index === editableStages.length - 1 ? 0.5 : 1,
                             }}
                           >
                             ↓
@@ -3300,29 +3143,26 @@ export default function SupervisorView() {
                       </div>
                       <div
                         style={{
-                          display: "flex",
-                          gap: "1rem",
-                          alignItems: "center",
+                          display: 'flex',
+                          gap: '1rem',
+                          alignItems: 'center',
                         }}
                       >
-                        <label style={{ fontSize: "0.875rem" }}>
+                        <label style={{ fontSize: '0.875rem' }}>
                           Standard Time (seconds):
                           <input
                             type="number"
                             value={stage.standardStageSeconds}
                             onChange={(e) =>
-                              updateStageSeconds(
-                                index,
-                                parseInt(e.target.value) || 0,
-                              )
+                              updateStageSeconds(index, parseInt(e.target.value) || 0)
                             }
                             min="0"
                             style={{
-                              marginLeft: "0.5rem",
-                              width: "100px",
-                              padding: "0.25rem",
-                              border: "1px solid var(--border)",
-                              borderRadius: "3px",
+                              marginLeft: '0.5rem',
+                              width: '100px',
+                              padding: '0.25rem',
+                              border: '1px solid var(--border)',
+                              borderRadius: '3px',
                             }}
                           />
                         </label>
@@ -3336,68 +3176,62 @@ export default function SupervisorView() {
             {/* Action Buttons */}
             <div
               style={{
-                display: "flex",
-                gap: "0.5rem",
-                justifyContent: "flex-end",
+                display: 'flex',
+                gap: '0.5rem',
+                justifyContent: 'flex-end',
               }}
             >
               <button
                 onClick={() => {
-                  setIsCreateModalOpen(false);
+                  setIsCreateModalOpen(false)
                   setNewWO({
-                    number: "",
-                    hullId: "",
-                    productSku: "",
+                    number: '',
+                    hullId: '',
+                    productSku: '',
                     qty: 1,
-                    model: "",
-                    trim: "",
-                    features: "",
-                    priority: "NORMAL",
-                    plannedStartDate: "",
-                    plannedFinishDate: "",
-                  });
-                  setSelectedModelId("");
-                  setSelectedTrimId("");
-                  setSelectedYear(new Date().getFullYear());
-                  setGeneratedSku("");
-                  setSelectedRoutingVersion(null);
-                  setEditableStages([]);
-                  setRoutingMode("default");
-                  setAvailableRoutingVersions([]);
+                    model: '',
+                    trim: '',
+                    features: '',
+                    priority: 'NORMAL',
+                    ...buildDefaultPlannedWindow(),
+                  })
+                  setSelectedModelId('')
+                  setSelectedTrimId('')
+                  setSelectedYear(new Date().getFullYear())
+                  setGeneratedSku('')
+                  setSelectedRoutingVersion(null)
+                  setEditableStages([])
+                  setRoutingMode('default')
+                  setAvailableRoutingVersions([])
                 }}
                 style={{
-                  padding: "0.5rem 1rem",
-                  backgroundColor: "var(--muted)",
-                  color: "var(--color-primary-foreground)",
-                  border: "none",
-                  borderRadius: "4px",
-                  cursor: "pointer",
+                  padding: '0.5rem 1rem',
+                  backgroundColor: 'var(--muted)',
+                  color: 'var(--color-primary-foreground)',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
                 }}
               >
                 Cancel
               </button>
               <button
                 onClick={createWorkOrder}
-                disabled={
-                  !newWO.hullId || !newWO.model || editableStages.length === 0
-                }
+                disabled={!newWO.hullId || !newWO.model || editableStages.length === 0}
                 style={{
-                  padding: "0.5rem 1rem",
+                  padding: '0.5rem 1rem',
                   backgroundColor:
                     !newWO.hullId || !newWO.model || editableStages.length === 0
-                      ? "var(--muted)"
-                      : "var(--color-success-600)",
-                  color: "var(--color-primary-foreground)",
-                  border: "none",
-                  borderRadius: "4px",
+                      ? 'var(--muted)'
+                      : 'var(--color-success-600)',
+                  color: 'var(--color-primary-foreground)',
+                  border: 'none',
+                  borderRadius: '4px',
                   cursor:
                     !newWO.hullId || !newWO.model || editableStages.length === 0
-                      ? "not-allowed"
-                      : "pointer",
-                  opacity:
-                    !newWO.hullId || !newWO.model || editableStages.length === 0
-                      ? 0.6
-                      : 1,
+                      ? 'not-allowed'
+                      : 'pointer',
+                  opacity: !newWO.hullId || !newWO.model || editableStages.length === 0 ? 0.6 : 1,
                 }}
               >
                 Create Work Order
@@ -3407,5 +3241,5 @@ export default function SupervisorView() {
         </div>
       )}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- add a shared helper to compute the default local 8:00–16:30 planning window for supervisor work orders
- apply the helper when initializing and resetting the create work order form to keep the modal defaults in sync
- log the missing local env variables that block API QA flows in the action item tracker

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68fa32672de483208d0dd0a4efd7af8d