### PR TITLE
Update replit documentation for October improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2025-10-23T17:15:00Z — Agent: Docs & Runbooks
+
+- **Summary:** Documented the supervisor planned-window helper and development login shortcuts in `replit.md`, corrected stack references to Tailwind + React 18, and logged the helper in the changelog.
+- **Reasoning:** Keep contributor documentation aligned with the Oct 16 and Oct 23 feature work so onboarding developers understand current defaults and tooling expectations.
+- **Hats:** docs.
+
 ## 2025-10-16T15:49:00Z — Agent: Docs & Runbooks
 
 - **Summary:** Strengthened agent workflow to MANDATE documenting all discovered issues in ActionItems.md. Updated AGENTS.md Executive Summary (#7 requirement), Documentation & Change Management (CRITICAL section), Testing Expectations, PR Checklist, Definition of Done, and all agent role descriptions. Updated ActionItems.md "How to Use" section and ONBOARDING.md development workflow with non-negotiable discovery documentation requirement.

--- a/replit.md
+++ b/replit.md
@@ -10,6 +10,16 @@ Preferred communication style: Simple, everyday language.
 
 ## Recent Updates - All Four Phases Completed
 
+### Supervisor Planned Window Helper (October 23, 2025)
+- **Auto-Populated Schedule**: Introduced `buildDefaultPlannedWindow` in the supervisor dashboard (`src/app/supervisor/page.tsx`) to seed new work orders with an 8:00 AM – 4:30 PM planned window.
+- **Next-Day Roll Forward**: When the current time is after the default start time, the helper advances the window to the next day to keep new work orders in the future.
+- **Modal Quality-of-Life**: Supervisor creation modal now opens with sensible defaults so planners only adjust when scheduling outside standard hours.
+
+### Dev Mode Quick Login Buttons (October 16, 2025)
+- **Role Shortcuts**: Added development-only quick launch buttons on the login page for Operator, Supervisor, and Admin demo accounts (`src/app/login/page.tsx`).
+- **Shared Auth Flow**: Buttons reuse the same fetch helper as the manual form, providing consistent error handling.
+- **Production Safety**: Production environments still show the standard credential form to preserve secure sign-in expectations.
+
 ### File Icon Standardization (October 16, 2025)
 - **Heroicons Integration**: Replaced all emoji file type icons in FileListDisplay component with standard Heroicons for consistency
 - **Icon Mapping**: Complete file type icon system using @heroicons/react/24/solid:
@@ -82,7 +92,7 @@ Preferred communication style: Simple, everyday language.
 
 ### Frontend Architecture
 - **Framework**: Next.js 14 with App Router and TypeScript
-- **Styling**: CSS with utility classes and custom CSS modules
+- **Styling**: Tailwind CSS with shared theme tokens defined in `tailwind.config.js`
 - **State Management**: React hooks (useState, useEffect) for client-side state
 - **Routing**: File-based routing with protected route middleware
 - **Authentication Flow**: JWT-based authentication with HTTP-only cookies
@@ -111,7 +121,7 @@ Preferred communication style: Simple, everyday language.
 
 ### Core Framework Dependencies
 - **Next.js 14**: Full-stack React framework with App Router
-- **React 19**: Frontend UI library with latest features
+- **React 18.3**: Frontend UI library aligned with the versions pinned in `package.json`
 - **TypeScript 5.9**: Type safety and development experience
 
 ### Database and ORM
@@ -129,6 +139,8 @@ Preferred communication style: Simple, everyday language.
 
 ### Development Tools
 - **TypeScript types**: @types packages for Node.js, React, bcryptjs, and jsonwebtoken
+- **Linting**: `npm run lint` and `npm run lint:fix` leverage the Next.js + ESLint configuration introduced on October 16, 2025.
+- **Formatting**: `npm run format` and `npm run format:check` apply the shared Prettier 3 rules—run them after edits to keep the repo consistent.
 
 ### Environment Configuration
 - **DATABASE_URL**: PostgreSQL connection string


### PR DESCRIPTION
## Summary
- document the Oct 23 supervisor planned-window helper and Oct 16 dev login shortcuts in replit.md
- align replit.md architecture and tooling notes with Tailwind styling, React 18, and the ESLint/Prettier scripts
- add a 2025-10-23 changelog entry capturing the documentation refresh

## Testing
- not run (docs only)

No issues discovered during this work.

------
https://chatgpt.com/codex/tasks/task_e_68fa4aa521308320bec26eb39b673a45