### PR TITLE
Add product configuration API helpers and contract tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2025-10-31T15:15:00Z — Agent: gpt-5-codex
+
+- **Summary:** Added product-configuration API endpoints with RBAC, Prisma-backed helpers, and contract tests to validate success and failure paths.
+- **Reasoning:** Supervisors and admins need a secure way to review and manage model configuration data without bypassing server validation rules.
+- **Changes Made:**
+  - Introduced `src/server/product-config/productConfigurations.ts` with zod-validated list and upsert helpers for sections, components, options, and dependencies.
+  - Added REST handlers under `src/app/api/product-configurations/**` enforcing role checks and structured JSON responses for listing and mutating configuration records.
+  - Wrote Vitest contract tests covering successful requests and validation errors for listing and mutation endpoints.
+- **Hats:** api-contract, security, qa-gate.
+
 ## 2025-10-30T12:30:00Z — Agent: gpt-5-codex
 
 - **Summary:** Extended the Prisma schema with a product configuration hierarchy, restored LX26/LX24/LX22/LX21 configuration data into the backup set, and exported strongly typed helpers for server-side configuration queries.

--- a/src/app/api/__tests__/product-configurations.test.ts
+++ b/src/app/api/__tests__/product-configurations.test.ts
@@ -1,0 +1,238 @@
+import { NextRequest } from 'next/server'
+import { describe, beforeEach, expect, it, vi } from 'vitest'
+import { ZodError } from 'zod'
+
+const {
+  getUserFromRequestMock,
+  listSectionsMock,
+  upsertSectionMock,
+  upsertComponentMock,
+  upsertOptionMock,
+} = vi.hoisted(() => ({
+  getUserFromRequestMock: vi.fn(),
+  listSectionsMock: vi.fn(),
+  upsertSectionMock: vi.fn(),
+  upsertComponentMock: vi.fn(),
+  upsertOptionMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getUserFromRequest: getUserFromRequestMock,
+}))
+
+vi.mock('@/server/product-config/productConfigurations', () => ({
+  listProductConfigurationSections: listSectionsMock,
+  upsertProductConfigurationSection: upsertSectionMock,
+  upsertProductConfigurationComponent: upsertComponentMock,
+  upsertProductConfigurationOption: upsertOptionMock,
+}))
+
+import { GET as listRoute } from '../product-configurations/[modelId]/route'
+import { POST as createSection } from '../product-configurations/sections/route'
+import { POST as createComponent } from '../product-configurations/components/route'
+import { POST as createOption } from '../product-configurations/options/route'
+
+function buildRequest(method: string, url: string, body?: unknown) {
+  return new NextRequest(url, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('Product configuration routes', () => {
+  beforeEach(() => {
+    getUserFromRequestMock.mockReset()
+    listSectionsMock.mockReset()
+    upsertSectionMock.mockReset()
+    upsertComponentMock.mockReset()
+    upsertOptionMock.mockReset()
+  })
+
+  describe('GET /api/product-configurations/[modelId]', () => {
+    it('returns configuration sections for supervisors', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'SUPERVISOR' })
+      listSectionsMock.mockResolvedValue([{ id: 'section-1', name: 'Electrical', components: [] }])
+
+      const response = await listRoute(
+        buildRequest('GET', 'https://example.com/api/product-configurations/model-1?trimId=trim-1'),
+        { params: { modelId: 'model-1' } }
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({
+        ok: true,
+        data: [{ id: 'section-1', name: 'Electrical', components: [] }],
+      })
+      expect(listSectionsMock).toHaveBeenCalledWith({ modelId: 'model-1', trimId: 'trim-1' })
+    })
+
+    it('returns 400 when query validation fails', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+
+      const response = await listRoute(
+        buildRequest('GET', 'https://example.com/api/product-configurations/model-1?trimId='),
+        { params: { modelId: 'model-1' } }
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.ok).toBe(false)
+      expect(payload.error).toBe('Invalid query parameters')
+      expect(listSectionsMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/product-configurations/sections', () => {
+    it('creates a section for admins', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+      upsertSectionMock.mockResolvedValue({ id: 'section-1', name: 'Electrical' })
+
+      const response = await createSection(
+        buildRequest('POST', 'https://example.com/api/product-configurations/sections', {
+          productModelId: 'model-1',
+          code: 'ELEC',
+          name: 'Electrical',
+          sortOrder: 1,
+          isRequired: true,
+        })
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ ok: true, data: { id: 'section-1', name: 'Electrical' } })
+      expect(upsertSectionMock).toHaveBeenCalledWith({
+        productModelId: 'model-1',
+        code: 'ELEC',
+        name: 'Electrical',
+        sortOrder: 1,
+        isRequired: true,
+      })
+    })
+
+    it('returns 400 when validation fails', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+      upsertSectionMock.mockRejectedValue(
+        new ZodError([
+          {
+            code: 'custom',
+            path: ['code'],
+            message: 'Required',
+          },
+        ])
+      )
+
+      const response = await createSection(
+        buildRequest('POST', 'https://example.com/api/product-configurations/sections', {})
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.ok).toBe(false)
+      expect(payload.error).toBe('Invalid request body')
+    })
+  })
+
+  describe('POST /api/product-configurations/components', () => {
+    it('creates a component for admins', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+      upsertComponentMock.mockResolvedValue({ id: 'component-1', name: 'Battery' })
+
+      const response = await createComponent(
+        buildRequest('POST', 'https://example.com/api/product-configurations/components', {
+          sectionId: 'section-1',
+          code: 'BAT',
+          name: 'Battery',
+          isRequired: true,
+          allowMultiple: false,
+          sortOrder: 1,
+        })
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ ok: true, data: { id: 'component-1', name: 'Battery' } })
+      expect(upsertComponentMock).toHaveBeenCalledWith({
+        sectionId: 'section-1',
+        code: 'BAT',
+        name: 'Battery',
+        isRequired: true,
+        allowMultiple: false,
+        sortOrder: 1,
+      })
+    })
+
+    it('returns 400 when validation fails', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+      upsertComponentMock.mockRejectedValue(
+        new ZodError([
+          {
+            code: 'custom',
+            path: ['sectionId'],
+            message: 'Required',
+          },
+        ])
+      )
+
+      const response = await createComponent(
+        buildRequest('POST', 'https://example.com/api/product-configurations/components', {})
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.ok).toBe(false)
+      expect(payload.error).toBe('Invalid request body')
+    })
+  })
+
+  describe('POST /api/product-configurations/options', () => {
+    it('creates an option for admins', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+      upsertOptionMock.mockResolvedValue({ id: 'option-1', name: 'AGM Battery' })
+
+      const response = await createOption(
+        buildRequest('POST', 'https://example.com/api/product-configurations/options', {
+          componentId: 'component-1',
+          code: 'AGM',
+          name: 'AGM Battery',
+          isActive: true,
+          sortOrder: 1,
+        })
+      )
+
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(payload).toEqual({ ok: true, data: { id: 'option-1', name: 'AGM Battery' } })
+      expect(upsertOptionMock).toHaveBeenCalledWith({
+        componentId: 'component-1',
+        code: 'AGM',
+        name: 'AGM Battery',
+        isActive: true,
+        sortOrder: 1,
+      })
+    })
+
+    it('returns 400 when validation fails', async () => {
+      getUserFromRequestMock.mockReturnValue({ userId: 'u1', role: 'ADMIN' })
+      upsertOptionMock.mockRejectedValue(
+        new ZodError([
+          {
+            code: 'custom',
+            path: ['componentId'],
+            message: 'Required',
+          },
+        ])
+      )
+
+      const response = await createOption(
+        buildRequest('POST', 'https://example.com/api/product-configurations/options', {})
+      )
+
+      expect(response.status).toBe(400)
+      const payload = await response.json()
+      expect(payload.ok).toBe(false)
+      expect(payload.error).toBe('Invalid request body')
+    })
+  })
+})

--- a/src/app/api/product-configurations/[modelId]/route.ts
+++ b/src/app/api/product-configurations/[modelId]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Role } from '@prisma/client'
+import { ZodError, z } from 'zod'
+
+import { getUserFromRequest } from '@/lib/auth'
+import { listProductConfigurationSections } from '@/server/product-config/productConfigurations'
+
+const querySchema = z.object({
+  modelId: z.string().min(1, 'Product model ID is required'),
+  trimId: z.string().min(1).optional(),
+})
+
+export async function GET(request: NextRequest, { params }: { params: { modelId: string } }) {
+  const user = getUserFromRequest(request)
+  if (!user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (user.role !== Role.ADMIN && user.role !== Role.SUPERVISOR) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+  }
+
+  const url = new URL(request.url)
+  const parseResult = querySchema.safeParse({
+    modelId: params.modelId,
+    trimId: url.searchParams.get('trimId') ?? undefined,
+  })
+
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Invalid query parameters',
+        issues: parseResult.error.flatten(),
+      },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const sections = await listProductConfigurationSections(parseResult.data)
+    return NextResponse.json({ ok: true, data: sections })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid request', issues: error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/product-configurations/components/route.ts
+++ b/src/app/api/product-configurations/components/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Role } from '@prisma/client'
+import { ZodError } from 'zod'
+
+import { getUserFromRequest } from '@/lib/auth'
+import { upsertProductConfigurationComponent } from '@/server/product-config/productConfigurations'
+
+async function handleRequest(request: NextRequest) {
+  const user = getUserFromRequest(request)
+  if (!user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (user.role !== Role.ADMIN) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const body = await request.json()
+    const component = await upsertProductConfigurationComponent(body)
+    return NextResponse.json({ ok: true, data: component })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid request body', issues: error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleRequest(request)
+}
+
+export async function PUT(request: NextRequest) {
+  return handleRequest(request)
+}

--- a/src/app/api/product-configurations/options/route.ts
+++ b/src/app/api/product-configurations/options/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Role } from '@prisma/client'
+import { ZodError } from 'zod'
+
+import { getUserFromRequest } from '@/lib/auth'
+import { upsertProductConfigurationOption } from '@/server/product-config/productConfigurations'
+
+async function handleRequest(request: NextRequest) {
+  const user = getUserFromRequest(request)
+  if (!user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (user.role !== Role.ADMIN) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const body = await request.json()
+    const option = await upsertProductConfigurationOption(body)
+    return NextResponse.json({ ok: true, data: option })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid request body', issues: error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleRequest(request)
+}
+
+export async function PUT(request: NextRequest) {
+  return handleRequest(request)
+}

--- a/src/app/api/product-configurations/sections/route.ts
+++ b/src/app/api/product-configurations/sections/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Role } from '@prisma/client'
+import { ZodError } from 'zod'
+
+import { getUserFromRequest } from '@/lib/auth'
+import { upsertProductConfigurationSection } from '@/server/product-config/productConfigurations'
+
+async function handleRequest(request: NextRequest) {
+  const user = getUserFromRequest(request)
+  if (!user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (user.role !== Role.ADMIN) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const body = await request.json()
+    const section = await upsertProductConfigurationSection(body)
+    return NextResponse.json({ ok: true, data: section })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { ok: false, error: 'Invalid request body', issues: error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return handleRequest(request)
+}
+
+export async function PUT(request: NextRequest) {
+  return handleRequest(request)
+}

--- a/src/server/product-config/productConfigurations.ts
+++ b/src/server/product-config/productConfigurations.ts
@@ -1,0 +1,321 @@
+import { Prisma, ProductConfigurationDependencyType } from '@prisma/client'
+import { prisma } from '@/server/db/client'
+import { ZodError, ZodIssueCode, z } from 'zod'
+
+const listInputSchema = z.object({
+  modelId: z.string().min(1, 'Product model ID is required'),
+  trimId: z.string().min(1).optional(),
+})
+
+const sectionInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  productModelId: z.string().min(1, 'Product model ID is required'),
+  productTrimId: z.string().min(1).optional().nullable(),
+  code: z.string().min(1, 'Section code is required'),
+  name: z.string().min(1, 'Section name is required'),
+  description: z.string().optional().nullable(),
+  sortOrder: z.number().int().default(0),
+  isRequired: z.boolean(),
+})
+
+const componentInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  sectionId: z.string().min(1, 'Section ID is required'),
+  code: z.string().min(1, 'Component code is required'),
+  name: z.string().min(1, 'Component name is required'),
+  description: z.string().optional().nullable(),
+  isRequired: z.boolean(),
+  allowMultiple: z.boolean(),
+  defaultOptionId: z.string().min(1).optional().nullable(),
+  sortOrder: z.number().int().default(0),
+})
+
+const dependencyInputSchema = z.object({
+  dependsOnOptionId: z.string().min(1, 'Dependency option ID is required'),
+  dependencyType: z.nativeEnum(ProductConfigurationDependencyType),
+})
+
+const optionInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  componentId: z.string().min(1, 'Component ID is required'),
+  code: z.string().min(1, 'Option code is required'),
+  partNumber: z.string().optional().nullable(),
+  name: z.string().min(1, 'Option name is required'),
+  description: z.string().optional().nullable(),
+  isActive: z.boolean().default(true),
+  isDefault: z.boolean().optional().default(false),
+  sortOrder: z.number().int().nonnegative().default(0),
+  dependencies: z.array(dependencyInputSchema).optional().default([]),
+})
+
+function createZodError(path: (string | number)[], message: string) {
+  return new ZodError([
+    {
+      code: ZodIssueCode.custom,
+      path,
+      message,
+    },
+  ])
+}
+
+export async function listProductConfigurationSections(input: {
+  modelId: string
+  trimId?: string
+}) {
+  const params = listInputSchema.parse(input)
+
+  return prisma.productConfigurationSection.findMany({
+    where: {
+      productModelId: params.modelId,
+      productTrimId: params.trimId ?? undefined,
+    },
+    include: {
+      productModel: true,
+      productTrim: true,
+      components: {
+        include: {
+          options: {
+            include: {
+              dependencies: true,
+              dependents: true,
+            },
+            orderBy: { sortOrder: 'asc' },
+          },
+        },
+        orderBy: { sortOrder: 'asc' },
+      },
+    },
+    orderBy: { sortOrder: 'asc' },
+  })
+}
+
+export async function upsertProductConfigurationSection(input: z.input<typeof sectionInputSchema>) {
+  const data = sectionInputSchema.parse(input)
+
+  const payload = {
+    productModelId: data.productModelId,
+    productTrimId: data.productTrimId ?? null,
+    code: data.code,
+    name: data.name,
+    description: data.description ?? null,
+    sortOrder: data.sortOrder,
+    isRequired: data.isRequired,
+  }
+
+  if (data.id) {
+    return prisma.productConfigurationSection.update({
+      where: { id: data.id },
+      data: payload,
+      include: {
+        components: {
+          include: { options: true },
+        },
+      },
+    })
+  }
+
+  return prisma.productConfigurationSection.create({
+    data: payload,
+    include: {
+      components: {
+        include: { options: true },
+      },
+    },
+  })
+}
+
+export async function upsertProductConfigurationComponent(
+  input: z.input<typeof componentInputSchema>
+) {
+  const data = componentInputSchema.parse(input)
+  const payload = {
+    sectionId: data.sectionId,
+    code: data.code,
+    name: data.name,
+    description: data.description ?? null,
+    isRequired: data.isRequired,
+    allowMultiple: data.allowMultiple,
+    defaultOptionId: data.defaultOptionId ?? null,
+    sortOrder: data.sortOrder,
+  }
+
+  if (payload.defaultOptionId) {
+    if (!data.id) {
+      throw createZodError(
+        ['defaultOptionId'],
+        'Component ID is required when setting a default option'
+      )
+    }
+
+    const option = await prisma.productConfigurationOption.findUnique({
+      where: { id: payload.defaultOptionId },
+      select: { componentId: true },
+    })
+
+    if (!option || option.componentId !== data.id) {
+      throw createZodError(['defaultOptionId'], 'Default option does not belong to this component')
+    }
+  }
+
+  if (data.id) {
+    const component = await prisma.productConfigurationComponent.update({
+      where: { id: data.id },
+      data: payload,
+      include: {
+        options: {
+          include: {
+            dependencies: true,
+            dependents: true,
+          },
+        },
+      },
+    })
+
+    return component
+  }
+
+  return prisma.productConfigurationComponent.create({
+    data: payload,
+    include: {
+      options: {
+        include: {
+          dependencies: true,
+          dependents: true,
+        },
+      },
+    },
+  })
+}
+
+async function ensureDependencyOptionsExist(optionIds: string[]) {
+  if (optionIds.length === 0) {
+    return
+  }
+
+  const options = await prisma.productConfigurationOption.findMany({
+    where: { id: { in: optionIds } },
+    select: { id: true },
+  })
+
+  const missing = optionIds.filter((id) => !options.find((option) => option.id === id))
+
+  if (missing.length > 0) {
+    throw createZodError(['dependencies'], `Unknown dependency option IDs: ${missing.join(', ')}`)
+  }
+}
+
+export async function upsertProductConfigurationOption(input: z.input<typeof optionInputSchema>) {
+  const data = optionInputSchema.parse(input)
+
+  const dependencyIds = data.dependencies.map((dependency) => dependency.dependsOnOptionId)
+  if (data.id && dependencyIds.includes(data.id)) {
+    throw createZodError(['dependencies'], 'Option cannot depend on itself')
+  }
+
+  await ensureDependencyOptionsExist(dependencyIds)
+
+  const payload = {
+    componentId: data.componentId,
+    code: data.code,
+    partNumber: data.partNumber ?? null,
+    name: data.name,
+    description: data.description ?? null,
+    isActive: data.isActive,
+    isDefault: data.isDefault ?? false,
+    sortOrder: data.sortOrder,
+  }
+
+  if (data.id) {
+    const result = await prisma.$transaction(async (tx) => {
+      const option = await tx.productConfigurationOption.update({
+        where: { id: data.id },
+        data: payload,
+        include: {
+          dependencies: true,
+          dependents: true,
+        },
+      })
+
+      await tx.productConfigurationDependency.deleteMany({
+        where: { optionId: option.id },
+      })
+
+      if (data.dependencies.length > 0) {
+        await tx.productConfigurationDependency.createMany({
+          data: data.dependencies.map((dependency) => ({
+            optionId: option.id,
+            dependsOnOptionId: dependency.dependsOnOptionId,
+            dependencyType: dependency.dependencyType,
+          })),
+        })
+      }
+
+      await updateComponentDefaultOption(tx, option.componentId, option.id, data.isDefault ?? false)
+
+      return option
+    })
+
+    return result
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const option = await tx.productConfigurationOption.create({
+      data: payload,
+      include: {
+        dependencies: true,
+        dependents: true,
+      },
+    })
+
+    if (data.dependencies.length > 0) {
+      await tx.productConfigurationDependency.createMany({
+        data: data.dependencies.map((dependency) => ({
+          optionId: option.id,
+          dependsOnOptionId: dependency.dependsOnOptionId,
+          dependencyType: dependency.dependencyType,
+        })),
+      })
+    }
+
+    await updateComponentDefaultOption(tx, option.componentId, option.id, data.isDefault ?? false)
+
+    return option
+  })
+
+  return result
+}
+
+async function updateComponentDefaultOption(
+  tx: Prisma.TransactionClient,
+  componentId: string,
+  optionId: string,
+  isDefault: boolean
+) {
+  if (isDefault) {
+    await tx.productConfigurationOption.updateMany({
+      where: {
+        componentId,
+        id: { not: optionId },
+      },
+      data: { isDefault: false },
+    })
+
+    await tx.productConfigurationComponent.update({
+      where: { id: componentId },
+      data: { defaultOptionId: optionId },
+    })
+  } else {
+    await tx.productConfigurationComponent.updateMany({
+      where: {
+        id: componentId,
+        defaultOptionId: optionId,
+      },
+      data: { defaultOptionId: null },
+    })
+  }
+}
+
+export type ListProductConfigurationSectionsInput = z.input<typeof listInputSchema>
+export type UpsertProductConfigurationSectionInput = z.input<typeof sectionInputSchema>
+export type UpsertProductConfigurationComponentInput = z.input<typeof componentInputSchema>
+export type UpsertProductConfigurationOptionInput = z.input<typeof optionInputSchema>


### PR DESCRIPTION
## Summary
- add server-side product configuration helpers that wrap Prisma mutations with zod validation
- expose REST endpoints under /api/product-configurations for listing and upserting sections, components, and options with RBAC
- cover new handlers with Vitest contract tests for happy paths and validation failures

## Testing
- npm run test

No issues discovered during this work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135091189c83208cebcb10efac5477)