### PR TITLE
Fix work order PATCH audit log payload fields

### DIFF
--- a/docs/ActionItems.md
+++ b/docs/ActionItems.md
@@ -34,6 +34,13 @@ This document tracks outstanding tasks, improvements, and technical debt for the
   - **Agent role**: QA & Release Gate
   - **Discovered**: 2025-01-16 during ESLint/Prettier setup
 
+- [ ] **Resolve npm "Unknown env config http-proxy" warning**
+  - Warning appears when running `npx prettier@3 --write`
+  - Investigate npm config/environment to remove deprecated `http-proxy` setting
+  - **Estimated effort**: 15 minutes
+  - **Agent role**: QA & Release Gate
+  - **Discovered**: 2026-01-07 during Prettier formatting
+
 - [ ] **Remove console.log statements from production code**
   - Create structured logging utility in `src/lib/logger.ts`
   - Replace console.log/warn/error in 17 files flagged by ESLint

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2026-01-07T17:18:34Z - Agent: Codex (api-contract, qa-gate, docs)
+
+- **Summary:** Updated the work order PATCH audit log writes to use schema-aligned fields and capture update details in the `after` payload. Logged the npm `http-proxy` config warning in ActionItems for follow-up.
+- **Reasoning:** Audit logs must align with the `AuditLog` model fields to keep API handlers consistent and avoid schema drift.
+- **Validation:** Not run (not requested).
+- **Files Modified:** `src/app/api/work-orders/[id]/route.ts`, `docs/ActionItems.md`, `docs/CHANGELOG.md`
 
 ## 2025-10-27T20:30:26Z - Agent: Codex (role-ui, qa-gate, docs)
 
@@ -29,7 +35,6 @@
   - Seeded LX-series configuration sections, components, options, and dependency links via `backup-data.ts` and `seed.ts` for deterministic reseeds.
   - Introduced server typings for configuration payloads to keep API layers aligned with the expanded schema.
 - **Hats:** domain, schema-change, seed, docs.
-
 
 ## 2025-10-27T21:00:00Z — Agent: QA & Release Gate
 


### PR DESCRIPTION
### Motivation

- Ensure audit log entries written by the work-order PATCH handler match the `AuditLog` Prisma model fields and are consistent with other routes.
- Preserve existing `WorkOrderVersion` snapshot behavior while improving audit payload structure for downstream consumers.
- Avoid schema drift and make audit records easier to query by storing change details in the `after` JSON field.
- Record an incidental npm environment warning discovered while formatting for follow-up in ActionItems.

### Description

- Replaced the previous `auditLog.createMany` payload keys and shape in `src/app/api/work-orders/[id]/route.ts` to use `model`, `modelId`, `action`, `before`, and `after` and removed the old `modelType`, `changes`, and `metadata` fields.
- Put change details and serialized update data into `after` (e.g. `after: { message: change, workOrderNumber: updated.number, ... }`) and set `before: null` for now.
- Left the `WorkOrderVersion` snapshot creation logic unchanged so each update still writes a versioned snapshot with `schema_hash` and `versionNumber`.
- Updated `docs/ActionItems.md` to log the npm `http-proxy` config warning and appended a changelog entry in `docs/CHANGELOG.md` describing the change.

### Testing

- No unit/contract/Vitest tests were executed as part of this change.
- Ran `npx prettier@3 --write src/app/api/work-orders/[id]/route.ts docs/ActionItems.md docs/CHANGELOG.md`, which formatted the files successfully but produced an npm warning `Unknown env config "http-proxy"` that was recorded in ActionItems for follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9526a3908320ba58a9ff25e269d9)