### PR TITLE
docs: update CHANGELOG for Replit supervisor dashboard & audit/version fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2026-01-07T19:15:59Z - Agent: Codex (role-ui, api-contract, docs)
+
+- **Summary:** Documented today's Replit changes: added server-backed filtering/sorting/search for supervisor dashboard work orders, introduced filter controls and sortable columns in the supervisor table, added a Release action for planned work orders, refreshed global scrollbar styling with horizontal table overflow, and corrected work order version snapshot display plus audit log payload fields for version creation.
+- **Reasoning:** Ensure documentation reflects the latest supervisor workflow improvements, UI affordances, and audit/version metadata alignment delivered in the Replit checkpoints.
+- **Validation:** Not run (documentation-only update).
+- **Files Modified:** `docs/CHANGELOG.md`
+
 ## 2026-01-07T17:18:34Z - Agent: Codex (api-contract, qa-gate, docs)
 
 - **Summary:** Updated the work order PATCH audit log writes to use schema-aligned fields and capture update details in the `after` payload. Logged the npm `http-proxy` config warning in ActionItems for follow-up.


### PR DESCRIPTION
### Motivation
- Capture and document the Replit checkpoints that introduced supervisor dashboard filtering, sorting, search, and UI controls so the change history is accurate.
- Record related fixes to work order version snapshots and audit log payload fields to preserve traceability between code and docs.
- Surface the `npx prettier` environment warning discovered during formatting so it is tracked in `docs/ActionItems.md`.

### Description
- Added a new changelog entry at `2026-01-07T19:15:59Z` summarizing the supervisor dashboard and audit/version updates in `docs/CHANGELOG.md`.
- Recent code changes (recorded in commits) include server-side filtering/sorting/search and `filterOptions` in `src/app/api/supervisor/dashboard/route.ts` and a post-query work center filter.
- UI changes include search, debounced query, status/priority/model/work-center filters, sortable table columns, a `Release` action for `PLANNED` WOs, `overflowX: auto` for tables, and `snapshot` field usage in `src/app/supervisor/page.tsx`.
- Also corrected the work order version audit payload structure in `src/app/api/work-orders/[id]/versions/route.ts` and added custom scrollbar styles in `src/app/globals.css` (these code edits are summarized here; this PR only updates the changelog).

### Testing
- Ran `npx prettier@3 --write docs/CHANGELOG.md` which completed but emitted an npm warning: `Unknown env config "http-proxy"`.
- No unit/integration/Vitest suites were executed as part of this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb0ad39388320bf467af77b6a7d47)