### PR TITLE
Update ActionItems and Changelog: promote supervisor build-blocker, adjust logging scope, refresh API baseline

### DIFF
--- a/docs/ActionItems.md
+++ b/docs/ActionItems.md
@@ -34,9 +34,19 @@ This document tracks outstanding tasks, improvements, and technical debt for the
   - **Agent role**: QA & Release Gate
   - **Discovered**: 2025-01-16 during ESLint/Prettier setup
 
+- [ ] **Fix exported function in supervisor page component**
+  - File: `src/app/supervisor/page.tsx`
+  - Issue: `buildKanbanColumns` function is exported but shouldn't be
+  - Error: Next.js build fails with "Property 'buildKanbanColumns' is incompatible with index signature"
+  - Fix: Either unexport the function or move it to a separate utility file
+  - **Estimated effort**: 15 minutes
+  - **Agent role**: UI/UX Implementer
+  - **Discovered**: 2025-01-16 during build verification
+  - **Blocks**: Production builds
+
 - [ ] **Remove console.log statements from production code**
   - Create structured logging utility in `src/lib/logger.ts`
-  - Replace console.log/warn/error in 17 files flagged by ESLint
+  - Replace console.log/warn/error across API routes, UI components, and server utilities (count needs refresh; exceeds prior "17 files" baseline)
   - Files affected: API routes, components, server utilities
   - **Estimated effort**: 2-3 hours
   - **Agent role**: QA & Release Gate
@@ -88,7 +98,7 @@ This document tracks outstanding tasks, improvements, and technical debt for the
 ### Testing
 
 - [ ] **Expand API route test coverage**
-  - Current: 2 routes tested, 31 total routes
+  - Current: 3 routes tested (supervisor dashboard, product configurations, queues), 31 total routes
   - Target: All critical routes (auth, work-orders, queues)
   - Priority routes: `/api/auth/login`, `/api/work-orders/*`, `/api/queues/*`
   - **Estimated effort**: 4-6 hours
@@ -110,16 +120,6 @@ This document tracks outstanding tasks, improvements, and technical debt for the
 _(All medium priority admin panel UI tasks are complete - moved to Completed Items)_
 
 ### Bug Fixes
-
-- [ ] **Fix exported function in supervisor page component**
-  - File: `src/app/supervisor/page.tsx`
-  - Issue: `buildKanbanColumns` function is exported but shouldn't be
-  - Error: Next.js build fails with "Property 'buildKanbanColumns' is incompatible with index signature"
-  - Fix: Either unexport the function or move it to a separate utility file
-  - **Estimated effort**: 15 minutes
-  - **Agent role**: UI/UX Implementer
-  - **Discovered**: 2025-01-16 during build verification
-  - **Blocks**: Production builds
 
 ### Documentation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2026-01-08T14:32:41Z - Agent: Codex (qa-gate, docs)
+
+- **Summary:** Elevated the supervisor build-blocker ActionItem to high priority, updated the logging cleanup scope to reflect broader console usage, and refreshed the API test coverage baseline.  
+- **Reasoning:** Keep ActionItems aligned with current code realities and highlight build-blocking work.  
+- **Validation:** Not run (documentation-only update).  
+- **Files Modified:** `docs/ActionItems.md`, `docs/CHANGELOG.md`
+
 ## 2026-01-07T19:31:04Z - Agent: Codex (qa-gate, docs)
 
 - **Summary:** Removed the deprecated npm `http-proxy` environment config, replacing it with `npm_config_proxy`, and marked the warning resolution complete in ActionItems.


### PR DESCRIPTION
### Motivation

- Ensure a build-blocking supervisor issue is surfaced at high priority because `buildKanbanColumns` in the supervisor page causes Next.js build failures.  
- Clarify the intended scope of the logging cleanup because console usage is broader than previously documented.  
- Keep the testing baseline accurate by updating the API route coverage count to reflect newly validated routes.  

### Description

- Added a high-priority ActionItem to `docs/ActionItems.md` for the `buildKanbanColumns` export in `src/app/supervisor/page.tsx` noting the Next.js build error and recommended fixes.  
- Broadened the logging cleanup entry in `docs/ActionItems.md` to replace `console.log/warn/error` across API routes, UI components, and server utilities.  
- Updated the API route test baseline in `docs/ActionItems.md` to `3 routes tested (supervisor dashboard, product configurations, queues)`.  
- Appended a changelog entry to `docs/CHANGELOG.md` with timestamp `2026-01-08T14:32:41Z` documenting the ActionItems updates.  

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbda638508320bd55ca0181242863)