### PR TITLE
Mock routingVersion in supervisor dashboard test to fix failing contract test

### DIFF
--- a/docs/ActionItems.md
+++ b/docs/ActionItems.md
@@ -98,14 +98,6 @@ This document tracks outstanding tasks, improvements, and technical debt for the
 
 ### Testing
 
-- [ ] **Fix failing supervisor dashboard contract test**
-  - Failure: `src/app/api/__tests__/supervisor.dashboard.test.ts` expects 200 but receives 500
-  - Error log: `TypeError: Cannot read properties of undefined (reading 'findMany')` in `src/app/api/supervisor/dashboard/route.ts:331`
-  - Repro: `npm run test`
-  - **Estimated effort**: 30-45 minutes
-  - **Agent role**: QA & Release Gate
-  - **Discovered**: 2026-01-08 during `npm run test`
-
 - [ ] **Expand API route test coverage**
   - Current: 3 routes tested (supervisor dashboard, product configurations, queues), 31 total routes
   - Target: All critical routes (auth, work-orders, queues)
@@ -377,6 +369,12 @@ _(All medium priority admin panel UI tasks are complete - moved to Completed Ite
 _(Items move here when marked complete with `[x]` status)_
 
 ### 2026-01-08
+
+- [x] **Fix failing supervisor dashboard contract test** (Agent: QA & Release Gate, Completed: 2026-01-08)
+  - Failure: `src/app/api/__tests__/supervisor.dashboard.test.ts` expects 200 but receives 500
+  - Error log: `TypeError: Cannot read properties of undefined (reading 'findMany')` in `src/app/api/supervisor/dashboard/route.ts:331`
+  - Fix: Mocked `prisma.routingVersion.findMany` in the supervisor dashboard contract test.
+  - **Discovered**: 2026-01-08 during `npm run test`
 
 - [x] **Add LICENSE file** (Agent: Docs & Runbooks, Completed: 2026-01-08)
   - Package.json specifies "ISC" but file is missing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2026-01-08T15:37:27Z - Agent: Codex (qa-gate, docs)
+
+- **Summary:** Mocked the routing version query in the supervisor dashboard contract test to prevent the 500 response and marked the action item complete.
+- **Reasoning:** The test suite failed because `prisma.routingVersion.findMany` was undefined in the mocked client; adding the mock keeps contract coverage stable and removes the blocking failure.
+- **Validation:** `npm run test`
+- **Files Modified:** `src/app/api/__tests__/supervisor.dashboard.test.ts`, `docs/ActionItems.md`, `docs/CHANGELOG.md`
+
 ## 2026-01-08T15:11:13Z - Agent: Codex (docs)
 
 - **Summary:** Added the missing ISC LICENSE file and marked the ActionItems task complete.

--- a/src/app/api/__tests__/supervisor.dashboard.test.ts
+++ b/src/app/api/__tests__/supervisor.dashboard.test.ts
@@ -1,20 +1,22 @@
-import { NextRequest } from "next/server";
-import { describe, expect, it, beforeEach, vi } from "vitest";
-import { WOStatus, WOPriority } from "@prisma/client";
+import { NextRequest } from 'next/server'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { WOStatus, WOPriority } from '@prisma/client'
 
 const {
   findManyMock,
   countMock,
   stageLogFindManyMock,
+  routingVersionFindManyMock,
   getUserFromRequestMock,
 } = vi.hoisted(() => ({
   findManyMock: vi.fn(),
   countMock: vi.fn(),
   stageLogFindManyMock: vi.fn(),
+  routingVersionFindManyMock: vi.fn(),
   getUserFromRequestMock: vi.fn(),
-}));
+}))
 
-vi.mock("@/server/db/client", () => ({
+vi.mock('@/server/db/client', () => ({
   prisma: {
     workOrder: {
       findMany: findManyMock,
@@ -23,93 +25,97 @@ vi.mock("@/server/db/client", () => ({
     wOStageLog: {
       findMany: stageLogFindManyMock,
     },
+    routingVersion: {
+      findMany: routingVersionFindManyMock,
+    },
   },
-}));
+}))
 
-vi.mock("@/lib/auth", () => ({
+vi.mock('@/lib/auth', () => ({
   getUserFromRequest: getUserFromRequestMock,
-}));
+}))
 
-import { GET } from "../supervisor/dashboard/route";
+import { GET } from '../supervisor/dashboard/route'
 
 function buildRequest(url: string) {
-  return new NextRequest(url);
+  return new NextRequest(url)
 }
 
-describe("GET /api/supervisor/dashboard", () => {
+describe('GET /api/supervisor/dashboard', () => {
   beforeEach(() => {
-    findManyMock.mockReset();
-    countMock.mockReset();
-    stageLogFindManyMock.mockReset();
-    getUserFromRequestMock.mockReset();
-  });
+    findManyMock.mockReset()
+    countMock.mockReset()
+    stageLogFindManyMock.mockReset()
+    routingVersionFindManyMock.mockReset()
+    getUserFromRequestMock.mockReset()
+  })
 
-  it("returns stage metadata and an ordered work-center list", async () => {
+  it('returns stage metadata and an ordered work-center list', async () => {
     getUserFromRequestMock.mockReturnValue({
-      userId: "user-1",
-      role: "SUPERVISOR",
-    });
+      userId: 'user-1',
+      role: 'SUPERVISOR',
+    })
 
-    const createdAt = new Date("2025-02-01T00:00:00Z");
+    const createdAt = new Date('2025-02-01T00:00:00Z')
 
     findManyMock.mockResolvedValue([
       {
-        id: "wo-1",
-        number: "WO-1",
-        hullId: "H1",
-        productSku: "SKU-1",
+        id: 'wo-1',
+        number: 'WO-1',
+        hullId: 'H1',
+        productSku: 'SKU-1',
         status: WOStatus.IN_PROGRESS,
         priority: WOPriority.HIGH,
         qty: 2,
         plannedStartDate: createdAt,
-        plannedFinishDate: new Date("2025-02-05T00:00:00Z"),
+        plannedFinishDate: new Date('2025-02-05T00:00:00Z'),
         currentStageIndex: 1,
         createdAt,
         routingVersion: {
           stages: [
             {
-              id: "stage-1",
-              code: "CUT",
-              name: "Cutting",
+              id: 'stage-1',
+              code: 'CUT',
+              name: 'Cutting',
               sequence: 1,
               enabled: true,
               workCenter: {
-                id: "wc-1",
-                name: "Cutting Center",
+                id: 'wc-1',
+                name: 'Cutting Center',
                 isActive: true,
-                department: { id: "dept-1", name: "Cutting" },
+                department: { id: 'dept-1', name: 'Cutting' },
               },
             },
             {
-              id: "stage-2",
-              code: "LAM",
-              name: "Lamination",
+              id: 'stage-2',
+              code: 'LAM',
+              name: 'Lamination',
               sequence: 2,
               enabled: true,
               workCenter: {
-                id: "wc-2",
-                name: "Lamination Center",
+                id: 'wc-2',
+                name: 'Lamination Center',
                 isActive: true,
-                department: { id: "dept-2", name: "Lamination" },
+                department: { id: 'dept-2', name: 'Lamination' },
               },
             },
           ],
         },
         woStageLogs: [
           {
-            event: "START",
+            event: 'START',
             createdAt,
-            user: { email: "operator@example.com" },
-            station: { code: "CUT-1" },
+            user: { email: 'operator@example.com' },
+            station: { code: 'CUT-1' },
           },
         ],
         _count: { notes: 1, attachments: 0 },
       },
       {
-        id: "wo-2",
-        number: "WO-2",
-        hullId: "H2",
-        productSku: "SKU-2",
+        id: 'wo-2',
+        number: 'WO-2',
+        hullId: 'H2',
+        productSku: 'SKU-2',
         status: WOStatus.RELEASED,
         priority: WOPriority.NORMAL,
         qty: 1,
@@ -120,16 +126,16 @@ describe("GET /api/supervisor/dashboard", () => {
         routingVersion: {
           stages: [
             {
-              id: "stage-3",
-              code: "QA",
-              name: "Quality Assurance",
+              id: 'stage-3',
+              code: 'QA',
+              name: 'Quality Assurance',
               sequence: 3,
               enabled: true,
               workCenter: {
-                id: "wc-3",
-                name: "QA Bay",
+                id: 'wc-3',
+                name: 'QA Bay',
                 isActive: true,
-                department: { id: "dept-3", name: "QA" },
+                department: { id: 'dept-3', name: 'QA' },
               },
             },
           ],
@@ -137,54 +143,53 @@ describe("GET /api/supervisor/dashboard", () => {
         woStageLogs: [],
         _count: { notes: 0, attachments: 1 },
       },
-    ]);
+    ])
 
-    countMock.mockResolvedValue(0);
-    stageLogFindManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0)
+    stageLogFindManyMock.mockResolvedValue([])
+    routingVersionFindManyMock.mockResolvedValue([{ model: 'LX24' }])
 
-    const response = await GET(
-      buildRequest("https://example.com/api/supervisor/dashboard"),
-    );
-    const payload = await response.json();
+    const response = await GET(buildRequest('https://example.com/api/supervisor/dashboard'))
+    const payload = await response.json()
 
-    expect(response.status).toBe(200);
-    expect(payload.success).toBe(true);
+    expect(response.status).toBe(200)
+    expect(payload.success).toBe(true)
 
-    const [firstWorkOrder] = payload.data.wipData;
+    const [firstWorkOrder] = payload.data.wipData
     expect(firstWorkOrder).toMatchObject({
-      id: "wo-1",
+      id: 'wo-1',
       priority: WOPriority.HIGH,
       plannedStartDate: createdAt.toISOString(),
       currentStage: {
-        id: "stage-2",
+        id: 'stage-2',
         sequence: 2,
-        workCenter: { id: "wc-2", name: "Lamination Center" },
-        department: { id: "dept-2", name: "Lamination" },
+        workCenter: { id: 'wc-2', name: 'Lamination Center' },
+        department: { id: 'dept-2', name: 'Lamination' },
       },
-    });
+    })
 
     expect(payload.data.workCenters).toEqual([
       {
-        id: "wc-1",
-        name: "Cutting Center",
-        departmentId: "dept-1",
-        departmentName: "Cutting",
+        id: 'wc-1',
+        name: 'Cutting Center',
+        departmentId: 'dept-1',
+        departmentName: 'Cutting',
         sequence: 1,
       },
       {
-        id: "wc-2",
-        name: "Lamination Center",
-        departmentId: "dept-2",
-        departmentName: "Lamination",
+        id: 'wc-2',
+        name: 'Lamination Center',
+        departmentId: 'dept-2',
+        departmentName: 'Lamination',
         sequence: 2,
       },
       {
-        id: "wc-3",
-        name: "QA Bay",
-        departmentId: "dept-3",
-        departmentName: "QA",
+        id: 'wc-3',
+        name: 'QA Bay',
+        departmentId: 'dept-3',
+        departmentName: 'QA',
         sequence: 3,
       },
-    ]);
-  });
-});
+    ])
+  })
+})


### PR DESCRIPTION
### Motivation

- The supervisor dashboard contract test was failing with a runtime `TypeError` because the mocked Prisma client lacked a `routingVersion.findMany` implementation used by the handler. 
- Stabilize the test suite so CI and local `npm run test` runs don't produce a blocking 500 in the supervisor dashboard test. 
- Keep ActionItems and the changelog aligned with the fix so the repository's tracking reflects the resolution. 

### Description

- Added a `routingVersionFindManyMock` and wired `prisma.routingVersion.findMany` into `src/app/api/__tests__/supervisor.dashboard.test.ts`. 
- Reset the new mock in `beforeEach` and return a minimal resolved value (`[{ model: 'LX24' }]`) in the test to satisfy route logic. 
- Updated `docs/ActionItems.md` to mark the related ActionItem complete and appended a changelog entry in `docs/CHANGELOG.md`. 

### Testing

- Ran the test suite with `npm run test` (Vitest) and the full test run passed (all test files executed successfully). 
- The run completed despite known non-blocking warnings (`npm` http-proxy notice and `baseline-browser-mapping` data age warning). 
- No automated tests failed as a result of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcefc1bfc83208e068e9848f96273)