### PR TITLE
Add API route tests and update documentation

### DIFF
--- a/docs/ActionItems.md
+++ b/docs/ActionItems.md
@@ -84,9 +84,9 @@ This document tracks outstanding tasks, improvements, and technical debt for the
 ### Testing
 
 - [WIP] **Expand API route test coverage** (Agent: QA & Release Gate - Claude Sonnet 4.5)
-  - Current: 20 routes tested across 11 test files
-  - Total routes: 55 API routes (36% coverage)
-  - All tests passing: **141 total tests** (up from 24 initially, +488% increase)
+  - Current: 26 routes tested across 17 test files
+  - Total routes: 55 API routes (47% coverage)
+  - All tests passing: **220 total tests** (up from 141, +56% increase; up from 24 initially, +817% increase)
   - **Phase 1 Complete**: ✅ All 4 critical routes tested (100%)
     - ✅ `POST /api/auth/login` - 10 tests (auth, validation, role-based redirects, cookies)
     - ✅ `POST /api/work-orders` - 13 tests (RBAC, routing validation, date validation, version snapshots, audit logs)
@@ -97,7 +97,14 @@ This document tracks outstanding tasks, improvements, and technical debt for the
     - ✅ `POST /api/work-orders/complete` - 19 tests (stage completion, quality tracking, stage advancement, final stage→COMPLETED)
     - ✅ `POST /api/work-orders/[id]/hold` - 14 tests (RBAC SUPERVISOR/ADMIN, reason validation, previous status preservation, audit logs)
     - ✅ `POST /api/work-orders/[id]/unhold` - 14 tests (status restoration from audit log, default to RELEASED, HOLD verification)
-  - **Next Steps**: Phase 3-5 available (35 routes remaining)
+  - **Phase 3 Complete**: ✅ All 6 additional state/auth routes tested (100%)
+    - ✅ `POST /api/work-orders/pause` - 17 tests (PAUSE event logging, no status change, department scoping, HOLD checks, station validation)
+    - ✅ `POST /api/work-orders/[id]/release` - 15 tests (RBAC SUPERVISOR/ADMIN, PLANNED→RELEASED transition, date validation, version snapshots, routing version status update)
+    - ✅ `GET /api/work-orders` - 11 tests (list with pagination, cursor support, ordering, includes, all roles)
+    - ✅ `GET /api/work-orders/[id]` - 15 tests (detail view, department scoping for operators, routing/stage includes, stage timeline)
+    - ✅ `POST /api/auth/logout` - 8 tests (cookie clearing, httpOnly, secure flag, sameSite, idempotent)
+    - ✅ `GET /api/auth/me` - 13 tests (token verification, user info, all roles, error handling, security)
+  - **Next Steps**: Phase 4-5 available (29 routes remaining)
   - **Agent role**: QA & Release Gate
 
 - [ ] **Set test coverage thresholds**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 > Record every pull request chronologically with the newest entry at the top. Use UTC timestamps in ISO 8601 format.
 
+## 2026-01-13T14:33:54Z - Agent: QA & Release Gate - Claude Sonnet 4.5
+
+- **Summary:** Phase 3: API route test expansion. Added comprehensive test coverage for 6 additional routes: work order pause/release, GET routes for list/detail, and auth logout/me endpoints. Increased total tests from 141 to 220 (+56% increase), now covering 26 of 55 routes (47% coverage).
+- **Reasoning:** Continuing systematic API route test expansion per ActionItems.md Phase 3 plan. These routes represent critical state transitions (pause, release), data retrieval (list, detail), and authentication flows (logout, me) that are essential for application stability. Testing these routes ensures proper RBAC enforcement, department scoping, pagination, and authentication security.
+- **Changes Made:**
+  - **Test Files Created** (6 new files):
+    - `src/app/api/__tests__/work-orders.pause.test.ts` - 17 tests for POST /api/work-orders/pause
+    - `src/app/api/__tests__/work-orders.release.test.ts` - 15 tests for POST /api/work-orders/[id]/release
+    - `src/app/api/__tests__/work-orders.list.test.ts` - 11 tests for GET /api/work-orders
+    - `src/app/api/__tests__/work-orders.detail.test.ts` - 15 tests for GET /api/work-orders/[id]
+    - `src/app/api/__tests__/auth.logout.test.ts` - 8 tests for POST /api/auth/logout
+    - `src/app/api/__tests__/auth.me.test.ts` - 13 tests for GET /api/auth/me
+  - **Test Setup Enhancement:** Added `RoutingVersionStatus` enum to `vitest.setup.ts` fallbackEnums to support release route tests
+  - **Coverage Details:**
+    - Pause route: Tests PAUSE event logging without status change, department scoping, HOLD checks, station validation, optional notes
+    - Release route: Tests RBAC (SUPERVISOR/ADMIN only), PLANNED→RELEASED transition, date validation past/future, version snapshots, routing version status updates, transaction handling
+    - List route: Tests pagination with cursor support, default/custom limits, hasMore indicator, ordering by createdAt desc, includes (routing version, counts), all roles
+    - Detail route: Tests department scoping (operators restricted, supervisors/admin unrestricted), current stage info, enabled stages list, nested includes, stage timeline
+    - Logout route: Tests cookie clearing with maxAge=0, httpOnly/secure/sameSite flags, idempotent behavior, works without auth
+    - Me route: Tests token verification, returns user info (userId/role/departmentId), all roles, error handling for missing/invalid/expired tokens, security (no sensitive info in errors)
+  - **Documentation:** Updated `docs/ActionItems.md` with Phase 3 completion status showing 26 routes tested (47% coverage), 220 tests passing
+- **Validation:** `npm test` - all 220 tests passing across 20 test files (up from 141 tests in 14 files)
+- **Files Modified:**
+  - New test files: 6 files in `src/app/api/__tests__/`
+  - Test setup: `vitest.setup.ts`
+  - Documentation: `docs/ActionItems.md`, `docs/CHANGELOG.md`
+- **Branch:** `claude/api-route-tests-eUqoF`
+- **Hats:** qa-gate, docs
+
 ## 2026-01-08T16:35:00Z - Agent: QA & Release Gate - Claude Sonnet 4.5
 
 - **Summary:** Phase 1: Critical fixes and code quality improvements. Fixed failing supervisor dashboard test, formatted entire codebase with Prettier (127 files), and implemented structured logging system replacing 188 console statements across 62 production files.

--- a/src/app/api/__tests__/auth.logout.test.ts
+++ b/src/app/api/__tests__/auth.logout.test.ts
@@ -1,0 +1,105 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it } from 'vitest'
+
+// Import the route handler
+import { POST } from '../auth/logout/route'
+
+function buildRequest() {
+  return new NextRequest('https://example.com/api/auth/logout', {
+    method: 'POST',
+  })
+}
+
+describe('POST /api/auth/logout', () => {
+  it('returns 200 with success:true', async () => {
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ success: true })
+  })
+
+  it('clears the token cookie with maxAge:0', async () => {
+    const response = await POST(buildRequest())
+
+    const setCookieHeaders = response.headers.getSetCookie()
+    expect(setCookieHeaders.length).toBeGreaterThan(0)
+
+    const tokenCookie = setCookieHeaders.find((header) => header.startsWith('token='))
+    expect(tokenCookie).toBeDefined()
+    expect(tokenCookie).toContain('token=;') // Empty value
+    expect(tokenCookie).toContain('Max-Age=0') // Expires immediately
+  })
+
+  it('sets cookie with httpOnly flag', async () => {
+    const response = await POST(buildRequest())
+
+    const setCookieHeaders = response.headers.getSetCookie()
+    const tokenCookie = setCookieHeaders.find((header) => header.startsWith('token='))
+
+    expect(tokenCookie).toContain('HttpOnly')
+  })
+
+  it('sets cookie with SameSite=Lax', async () => {
+    const response = await POST(buildRequest())
+
+    const setCookieHeaders = response.headers.getSetCookie()
+    const tokenCookie = setCookieHeaders.find((header) => header.startsWith('token='))
+
+    expect(tokenCookie?.toLowerCase()).toContain('samesite=lax')
+  })
+
+  it('sets secure flag in production environment', async () => {
+    const originalEnv = process.env.NODE_ENV
+
+    // Test production environment
+    process.env.NODE_ENV = 'production'
+
+    const response = await POST(buildRequest())
+
+    const setCookieHeaders = response.headers.getSetCookie()
+    const tokenCookie = setCookieHeaders.find((header) => header.startsWith('token='))
+
+    expect(tokenCookie).toContain('Secure')
+
+    // Restore environment
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('does not set secure flag in non-production environment', async () => {
+    const originalEnv = process.env.NODE_ENV
+
+    // Test development environment
+    process.env.NODE_ENV = 'development'
+
+    const response = await POST(buildRequest())
+
+    const setCookieHeaders = response.headers.getSetCookie()
+    const tokenCookie = setCookieHeaders.find((header) => header.startsWith('token='))
+
+    expect(tokenCookie).not.toContain('Secure')
+
+    // Restore environment
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('works without authentication (no token required to logout)', async () => {
+    // Logout should succeed even if user is not logged in
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(200)
+  })
+
+  it('returns same response regardless of prior authentication state', async () => {
+    // Test multiple logout calls
+    const response1 = await POST(buildRequest())
+    const response2 = await POST(buildRequest())
+
+    const payload1 = await response1.json()
+    const payload2 = await response2.json()
+
+    expect(payload1).toEqual(payload2)
+    expect(payload1).toEqual({ success: true })
+  })
+})

--- a/src/app/api/__tests__/auth.me.test.ts
+++ b/src/app/api/__tests__/auth.me.test.ts
@@ -1,0 +1,254 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { Role } from '@prisma/client'
+
+const { verifyTokenMock } = vi.hoisted(() => ({
+  verifyTokenMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyToken: verifyTokenMock,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// Import after mocks
+import { GET } from '../auth/me/route'
+
+function buildRequest(token?: string) {
+  const request = new NextRequest('https://example.com/api/auth/me', {
+    method: 'GET',
+  })
+
+  if (token) {
+    // Set cookie manually
+    request.cookies.set('token', token)
+  }
+
+  return request
+}
+
+describe('GET /api/auth/me', () => {
+  beforeEach(() => {
+    verifyTokenMock.mockReset()
+  })
+
+  it('returns 200 with user info when valid token provided', async () => {
+    const mockUser = {
+      userId: 'user-123',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    }
+
+    verifyTokenMock.mockReturnValue(mockUser)
+
+    const response = await GET(buildRequest('valid-token'))
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      ok: true,
+      user: mockUser,
+    })
+  })
+
+  it('returns user info with OPERATOR role', async () => {
+    const mockUser = {
+      userId: 'operator-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-2',
+    }
+
+    verifyTokenMock.mockReturnValue(mockUser)
+
+    const response = await GET(buildRequest('valid-token'))
+
+    const payload = await response.json()
+
+    expect(payload.ok).toBe(true)
+    expect(payload.user.role).toBe(Role.OPERATOR)
+    expect(payload.user.departmentId).toBe('dept-2')
+  })
+
+  it('returns user info with ADMIN role', async () => {
+    const mockUser = {
+      userId: 'admin-1',
+      role: Role.ADMIN,
+      departmentId: null,
+    }
+
+    verifyTokenMock.mockReturnValue(mockUser)
+
+    const response = await GET(buildRequest('valid-token'))
+
+    const payload = await response.json()
+
+    expect(payload.ok).toBe(true)
+    expect(payload.user.role).toBe(Role.ADMIN)
+    expect(payload.user.departmentId).toBeNull()
+  })
+
+  it('verifies token using verifyToken helper', async () => {
+    const mockUser = {
+      userId: 'user-123',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    }
+
+    verifyTokenMock.mockReturnValue(mockUser)
+
+    await GET(buildRequest('test-token-abc'))
+
+    expect(verifyTokenMock).toHaveBeenCalledWith('test-token-abc')
+  })
+
+  it('returns 401 when no token cookie provided', async () => {
+    const response = await GET(buildRequest())
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'No token provided',
+    })
+    expect(verifyTokenMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when token is empty string', async () => {
+    const response = await GET(buildRequest(''))
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'No token provided',
+    })
+    expect(verifyTokenMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when token verification throws error', async () => {
+    verifyTokenMock.mockImplementation(() => {
+      throw new Error('Invalid token signature')
+    })
+
+    const response = await GET(buildRequest('invalid-token'))
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      ok: false,
+      error: 'Invalid token',
+    })
+  })
+
+  it('returns 401 when token is expired', async () => {
+    verifyTokenMock.mockImplementation(() => {
+      throw new Error('Token expired')
+    })
+
+    const response = await GET(buildRequest('expired-token'))
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload.ok).toBe(false)
+    expect(payload.error).toBe('Invalid token')
+  })
+
+  it('returns 401 when token is malformed', async () => {
+    verifyTokenMock.mockImplementation(() => {
+      throw new Error('jwt malformed')
+    })
+
+    const response = await GET(buildRequest('malformed-token'))
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload.ok).toBe(false)
+    expect(payload.error).toBe('Invalid token')
+  })
+
+  it('includes all required user fields in response', async () => {
+    const mockUser = {
+      userId: 'user-123',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    }
+
+    verifyTokenMock.mockReturnValue(mockUser)
+
+    const response = await GET(buildRequest('valid-token'))
+
+    const payload = await response.json()
+
+    expect(payload.user).toHaveProperty('userId')
+    expect(payload.user).toHaveProperty('role')
+    expect(payload.user).toHaveProperty('departmentId')
+  })
+
+  it('handles user without department (null departmentId)', async () => {
+    const mockUser = {
+      userId: 'supervisor-1',
+      role: Role.SUPERVISOR,
+      departmentId: null,
+    }
+
+    verifyTokenMock.mockReturnValue(mockUser)
+
+    const response = await GET(buildRequest('valid-token'))
+
+    const payload = await response.json()
+
+    expect(payload.ok).toBe(true)
+    expect(payload.user.departmentId).toBeNull()
+  })
+
+  it('returns consistent structure for success and error responses', async () => {
+    // Success response
+    verifyTokenMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    const successResponse = await GET(buildRequest('valid-token'))
+    const successPayload = await successResponse.json()
+
+    expect(successPayload).toHaveProperty('ok')
+    expect(successPayload.ok).toBe(true)
+
+    // Error response
+    const errorResponse = await GET(buildRequest())
+    const errorPayload = await errorResponse.json()
+
+    expect(errorPayload).toHaveProperty('ok')
+    expect(errorPayload.ok).toBe(false)
+    expect(errorPayload).toHaveProperty('error')
+  })
+
+  it('does not expose sensitive token information in error messages', async () => {
+    verifyTokenMock.mockImplementation(() => {
+      throw new Error('JWT secret key is invalid')
+    })
+
+    const response = await GET(buildRequest('token-with-bad-secret'))
+
+    const payload = await response.json()
+
+    // Should return generic error, not expose secret details
+    expect(payload.error).toBe('Invalid token')
+    expect(payload.error).not.toContain('secret')
+  })
+})

--- a/src/app/api/__tests__/work-orders.detail.test.ts
+++ b/src/app/api/__tests__/work-orders.detail.test.ts
@@ -1,0 +1,465 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { Role, WOStatus, WOEvent } from '@prisma/client'
+
+const {
+  getUserFromRequestMock,
+  workOrderFindUniqueMock,
+} = vi.hoisted(() => ({
+  getUserFromRequestMock: vi.fn(),
+  workOrderFindUniqueMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getUserFromRequest: getUserFromRequestMock,
+}))
+
+vi.mock('@/server/db/client', () => ({
+  prisma: {
+    workOrder: {
+      findUnique: workOrderFindUniqueMock,
+    },
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// Import after mocks
+import { GET } from '../work-orders/[id]/route'
+
+function buildRequest() {
+  return new NextRequest('https://example.com/api/work-orders/wo-1', {
+    method: 'GET',
+  })
+}
+
+describe('GET /api/work-orders/[id]', () => {
+  const mockWorkOrder = {
+    id: 'wo-1',
+    number: 'WO-2025-001',
+    hullId: 'HULL-12345',
+    productSku: 'LX24-BASE',
+    qty: 1,
+    status: WOStatus.IN_PROGRESS,
+    priority: 'NORMAL',
+    plannedStartDate: new Date('2025-01-15'),
+    plannedFinishDate: new Date('2025-01-20'),
+    currentStageIndex: 1,
+    specSnapshot: {
+      model: 'LX24',
+      trim: 'Base',
+      features: {},
+    },
+    createdAt: new Date('2025-01-10'),
+    routingVersion: {
+      id: 'routing-1',
+      model: 'LX24',
+      trim: 'Base',
+      version: 1,
+      status: 'RELEASED',
+      stages: [
+        {
+          id: 'stage-1',
+          code: 'KITTING',
+          name: 'Kitting',
+          sequence: 1,
+          enabled: true,
+          workCenterId: 'wc-1',
+          standardStageSeconds: 3600,
+          workCenter: {
+            id: 'wc-1',
+            name: 'Kitting Center',
+            department: {
+              id: 'dept-1',
+              name: 'Assembly',
+            },
+            stations: [
+              {
+                id: 'station-1',
+                code: 'KIT-1',
+                name: 'Kitting Station 1',
+                isActive: true,
+              },
+            ],
+          },
+          workInstructionVersions: [],
+        },
+        {
+          id: 'stage-2',
+          code: 'LAMINATION',
+          name: 'Lamination',
+          sequence: 2,
+          enabled: true,
+          workCenterId: 'wc-2',
+          standardStageSeconds: 7200,
+          workCenter: {
+            id: 'wc-2',
+            name: 'Lamination Center',
+            department: {
+              id: 'dept-2',
+              name: 'Production',
+            },
+            stations: [],
+          },
+          workInstructionVersions: [],
+        },
+      ],
+    },
+    woStageLogs: [
+      {
+        id: 'log-1',
+        event: WOEvent.START,
+        createdAt: new Date('2025-01-15T08:00:00Z'),
+        goodQty: null,
+        scrapQty: null,
+        note: 'Starting kitting',
+        routingStage: {
+          id: 'stage-1',
+          name: 'Kitting',
+          code: 'KITTING',
+          workCenter: {
+            name: 'Kitting Center',
+          },
+        },
+        station: {
+          name: 'Kitting Station 1',
+          code: 'KIT-1',
+        },
+        user: {
+          id: 'user-1',
+          email: 'operator@example.com',
+          role: Role.OPERATOR,
+        },
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    getUserFromRequestMock.mockReset()
+    workOrderFindUniqueMock.mockReset()
+  })
+
+  it('returns 200 and work order details for supervisor', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.workOrder).toBeDefined()
+    expect(payload.workOrder.id).toBe('wo-1')
+    expect(payload.workOrder.number).toBe('WO-2025-001')
+    expect(payload.workOrder.status).toBe(WOStatus.IN_PROGRESS)
+    expect(payload.workOrder.currentStage).toBeDefined()
+    expect(payload.workOrder.currentStage.code).toBe('LAMINATION')
+  })
+
+  it('returns 200 and work order details for admin', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'admin-1',
+      role: Role.ADMIN,
+      departmentId: null,
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.workOrder.id).toBe('wo-1')
+  })
+
+  it('returns work order with routing version details', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    const payload = await response.json()
+
+    expect(payload.workOrder.routingVersion).toBeDefined()
+    expect(payload.workOrder.routingVersion.model).toBe('LX24')
+    expect(payload.workOrder.routingVersion.trim).toBe('Base')
+    expect(payload.workOrder.routingVersion.version).toBe(1)
+  })
+
+  it('returns current stage information', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    const payload = await response.json()
+
+    expect(payload.workOrder.currentStage).toEqual({
+      id: 'stage-2',
+      code: 'LAMINATION',
+      name: 'Lamination',
+      sequence: 2,
+      workCenter: 'Lamination Center',
+      department: 'Production',
+      standardSeconds: 7200,
+    })
+  })
+
+  it('returns enabled stages list', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    const payload = await response.json()
+
+    expect(payload.workOrder.enabledStages).toHaveLength(2)
+    expect(payload.workOrder.enabledStages[0].code).toBe('KITTING')
+    expect(payload.workOrder.enabledStages[1].code).toBe('LAMINATION')
+  })
+
+  it('allows operator to access work order in their department', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'operator-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-2', // Current stage department
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 403 when operator tries to access work order from different department', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'operator-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-3', // Different department
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(403)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Work order not in your department' })
+  })
+
+  it('allows supervisor to access work orders from any department', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'supervisor-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-3', // Different department
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('allows admin to access work orders from any department', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'admin-1',
+      role: Role.ADMIN,
+      departmentId: null, // No department
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    getUserFromRequestMock.mockReturnValue(null)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Unauthorized' })
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when work order not found', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(null)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-nonexistent' } })
+
+    expect(response.status).toBe(404)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Work order not found' })
+  })
+
+  it('includes work order stage logs', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+
+    // Verify query includes woStageLogs
+    expect(workOrderFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: 'wo-1' },
+      include: expect.objectContaining({
+        woStageLogs: expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        }),
+      }),
+    })
+  })
+
+  it('returns 500 when database operation fails', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockRejectedValue(new Error('Database error'))
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(500)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Internal server error' })
+  })
+
+  it('handles work order with no current stage gracefully', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    const workOrderAllStagesDisabled = {
+      ...mockWorkOrder,
+      routingVersion: {
+        ...mockWorkOrder.routingVersion,
+        stages: mockWorkOrder.routingVersion.stages.map((s) => ({
+          ...s,
+          enabled: false,
+        })),
+      },
+    }
+
+    workOrderFindUniqueMock.mockResolvedValue(workOrderAllStagesDisabled)
+
+    const response = await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.workOrder.currentStage).toBeNull()
+    expect(payload.workOrder.enabledStages).toHaveLength(0)
+  })
+
+  it('queries with full nested includes for work center and stages', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    await GET(buildRequest(), { params: { id: 'wo-1' } })
+
+    // Verify complex nested query structure
+    expect(workOrderFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: 'wo-1' },
+      include: {
+        routingVersion: {
+          include: {
+            stages: {
+              orderBy: { sequence: 'asc' },
+              include: {
+                workCenter: {
+                  include: {
+                    department: true,
+                    stations: {
+                      where: { isActive: true },
+                    },
+                  },
+                },
+                workInstructionVersions: {
+                  where: { isActive: true },
+                  orderBy: { version: 'desc' },
+                  take: 1,
+                },
+              },
+            },
+          },
+        },
+        woStageLogs: {
+          orderBy: { createdAt: 'desc' },
+          include: {
+            routingStage: {
+              include: {
+                workCenter: true,
+              },
+            },
+            station: true,
+            user: {
+              select: {
+                id: true,
+                email: true,
+                role: true,
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/app/api/__tests__/work-orders.list.test.ts
+++ b/src/app/api/__tests__/work-orders.list.test.ts
@@ -1,0 +1,348 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { Role, WOStatus } from '@prisma/client'
+
+const {
+  getUserFromRequestMock,
+  workOrderFindManyMock,
+  workOrderFindUniqueMock,
+} = vi.hoisted(() => ({
+  getUserFromRequestMock: vi.fn(),
+  workOrderFindManyMock: vi.fn(),
+  workOrderFindUniqueMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getUserFromRequest: getUserFromRequestMock,
+}))
+
+vi.mock('@/server/db/client', () => ({
+  prisma: {
+    workOrder: {
+      findMany: workOrderFindManyMock,
+      findUnique: workOrderFindUniqueMock,
+    },
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// Import after mocks
+import { GET } from '../work-orders/route'
+
+function buildRequest(searchParams?: Record<string, string>) {
+  const url = new URL('https://example.com/api/work-orders')
+  if (searchParams) {
+    Object.entries(searchParams).forEach(([key, value]) => {
+      url.searchParams.set(key, value)
+    })
+  }
+
+  return new NextRequest(url, {
+    method: 'GET',
+  })
+}
+
+describe('GET /api/work-orders (list)', () => {
+  const mockWorkOrders = [
+    {
+      id: 'wo-1',
+      number: 'WO-2025-001',
+      hullId: 'HULL-001',
+      productSku: 'LX24-BASE',
+      qty: 1,
+      status: WOStatus.IN_PROGRESS,
+      priority: 'NORMAL',
+      currentStageIndex: 1,
+      createdAt: new Date('2025-01-10'),
+      routingVersion: {
+        id: 'routing-1',
+        model: 'LX24',
+        trim: 'Base',
+        version: 1,
+      },
+      _count: {
+        notes: 3,
+        attachments: 2,
+      },
+    },
+    {
+      id: 'wo-2',
+      number: 'WO-2025-002',
+      hullId: 'HULL-002',
+      productSku: 'LX26-SPORT',
+      qty: 1,
+      status: WOStatus.RELEASED,
+      priority: 'HIGH',
+      currentStageIndex: 0,
+      createdAt: new Date('2025-01-09'),
+      routingVersion: {
+        id: 'routing-2',
+        model: 'LX26',
+        trim: 'Sport',
+        version: 1,
+      },
+      _count: {
+        notes: 1,
+        attachments: 0,
+      },
+    },
+  ]
+
+  beforeEach(() => {
+    getUserFromRequestMock.mockReset()
+    workOrderFindManyMock.mockReset()
+    workOrderFindUniqueMock.mockReset()
+  })
+
+  it('returns 200 and list of work orders for authenticated user', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue(mockWorkOrders)
+
+    const response = await GET(buildRequest())
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.data).toHaveLength(2)
+    expect(payload.data[0].id).toBe('wo-1')
+    expect(payload.data[0].number).toBe('WO-2025-001')
+    expect(payload.data[0].status).toBe(WOStatus.IN_PROGRESS)
+    expect(payload.data[1].id).toBe('wo-2')
+    expect(payload.nextCursor).toBeNull()
+    expect(payload.hasMore).toBe(false)
+  })
+
+  it('uses default limit of 20 when not specified', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue(mockWorkOrders)
+
+    await GET(buildRequest())
+
+    // Verify findMany called with limit + 1 (21) to determine hasMore
+    expect(workOrderFindManyMock).toHaveBeenCalledWith({
+      take: 21,
+      skip: 0,
+      cursor: undefined,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        routingVersion: true,
+        _count: {
+          select: {
+            notes: true,
+            attachments: true,
+          },
+        },
+      },
+    })
+  })
+
+  it('supports custom limit via query parameter', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue([mockWorkOrders[0]])
+
+    await GET(buildRequest({ limit: '10' }))
+
+    // Verify findMany called with limit + 1 (11)
+    expect(workOrderFindManyMock).toHaveBeenCalledWith({
+      take: 11,
+      skip: 0,
+      cursor: undefined,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        routingVersion: true,
+        _count: {
+          select: {
+            notes: true,
+            attachments: true,
+          },
+        },
+      },
+    })
+  })
+
+  it('supports cursor-based pagination', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue([mockWorkOrders[1]])
+
+    await GET(buildRequest({ cursor: 'wo-1', limit: '10' }))
+
+    // Verify cursor used and skip set to 1
+    expect(workOrderFindManyMock).toHaveBeenCalledWith({
+      take: 11,
+      skip: 1,
+      cursor: { id: 'wo-1' },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        routingVersion: true,
+        _count: {
+          select: {
+            notes: true,
+            attachments: true,
+          },
+        },
+      },
+    })
+  })
+
+  it('indicates hasMore when more records available', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    // Return limit + 1 items to indicate more available
+    const manyWorkOrders = Array.from({ length: 21 }, (_, i) => ({
+      ...mockWorkOrders[0],
+      id: `wo-${i + 1}`,
+      number: `WO-2025-${String(i + 1).padStart(3, '0')}`,
+    }))
+
+    workOrderFindManyMock.mockResolvedValue(manyWorkOrders)
+
+    const response = await GET(buildRequest({ limit: '20' }))
+
+    const payload = await response.json()
+
+    // Should return only 20 items (limit)
+    expect(payload.data).toHaveLength(20)
+    expect(payload.hasMore).toBe(true)
+    expect(payload.nextCursor).toBe('wo-20')
+  })
+
+  it('orders work orders by createdAt desc (newest first)', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue(mockWorkOrders)
+
+    await GET(buildRequest())
+
+    expect(workOrderFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { createdAt: 'desc' },
+      })
+    )
+  })
+
+  it('includes routing version and counts in response', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue(mockWorkOrders)
+
+    const response = await GET(buildRequest())
+
+    const payload = await response.json()
+
+    expect(payload.data[0]).toHaveProperty('routingVersion')
+    expect(payload.data[0]).toHaveProperty('_count')
+    expect(payload.data[0]._count).toEqual({
+      notes: 3,
+      attachments: 2,
+    })
+  })
+
+  it('returns empty list when no work orders exist', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockResolvedValue([])
+
+    const response = await GET(buildRequest())
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.data).toEqual([])
+    expect(payload.hasMore).toBe(false)
+    expect(payload.nextCursor).toBeNull()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    getUserFromRequestMock.mockReturnValue(null)
+
+    const response = await GET(buildRequest())
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Unauthorized' })
+    expect(workOrderFindManyMock).not.toHaveBeenCalled()
+  })
+
+  it('works for all roles (ADMIN, SUPERVISOR, OPERATOR)', async () => {
+    const roles = [Role.ADMIN, Role.SUPERVISOR, Role.OPERATOR]
+
+    for (const role of roles) {
+      getUserFromRequestMock.mockReset()
+      workOrderFindManyMock.mockReset()
+
+      getUserFromRequestMock.mockReturnValue({
+        userId: `user-${role}`,
+        role,
+        departmentId: role === Role.OPERATOR ? 'dept-1' : null,
+      })
+
+      workOrderFindManyMock.mockResolvedValue([mockWorkOrders[0]])
+
+      const response = await GET(buildRequest())
+
+      expect(response.status).toBe(200)
+    }
+  })
+
+  it('returns 500 when database operation fails', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindManyMock.mockRejectedValue(new Error('Database error'))
+
+    const response = await GET(buildRequest())
+
+    expect(response.status).toBe(500)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Internal server error' })
+  })
+})

--- a/src/app/api/__tests__/work-orders.pause.test.ts
+++ b/src/app/api/__tests__/work-orders.pause.test.ts
@@ -1,0 +1,548 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { Role, WOStatus, WOEvent } from '@prisma/client'
+
+const {
+  getUserFromRequestMock,
+  workOrderFindUniqueMock,
+  stationFindFirstMock,
+  woStageLogCreateMock,
+} = vi.hoisted(() => ({
+  getUserFromRequestMock: vi.fn(),
+  workOrderFindUniqueMock: vi.fn(),
+  stationFindFirstMock: vi.fn(),
+  woStageLogCreateMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getUserFromRequest: getUserFromRequestMock,
+}))
+
+vi.mock('@/server/db/client', () => ({
+  prisma: {
+    workOrder: {
+      findUnique: workOrderFindUniqueMock,
+    },
+    station: {
+      findFirst: stationFindFirstMock,
+    },
+    wOStageLog: {
+      create: woStageLogCreateMock,
+    },
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// Import after mocks
+import { POST } from '../work-orders/pause/route'
+
+function buildRequest(body: unknown, departmentId?: string) {
+  const url = departmentId
+    ? `https://example.com/api/work-orders/pause?departmentId=${departmentId}`
+    : 'https://example.com/api/work-orders/pause'
+
+  return new NextRequest(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/work-orders/pause', () => {
+  const mockWorkOrder = {
+    id: 'wo-1',
+    number: 'WO-2025-001',
+    hullId: 'HULL-12345',
+    status: WOStatus.IN_PROGRESS,
+    currentStageIndex: 0,
+    routingVersion: {
+      id: 'routing-1',
+      stages: [
+        {
+          id: 'stage-1',
+          code: 'KITTING',
+          name: 'Kitting',
+          sequence: 1,
+          enabled: true,
+          workCenterId: 'wc-1',
+          workCenter: {
+            id: 'wc-1',
+            name: 'Kitting Center',
+            department: {
+              id: 'dept-1',
+              name: 'Assembly',
+            },
+          },
+        },
+        {
+          id: 'stage-2',
+          code: 'LAMINATION',
+          name: 'Lamination',
+          sequence: 2,
+          enabled: true,
+          workCenterId: 'wc-2',
+          workCenter: {
+            id: 'wc-2',
+            name: 'Lamination Center',
+            department: {
+              id: 'dept-2',
+              name: 'Production',
+            },
+          },
+        },
+      ],
+    },
+  }
+
+  const mockStation = {
+    id: 'station-1',
+    code: 'KIT-1',
+    name: 'Kitting Station 1',
+    workCenterId: 'wc-1',
+    isActive: true,
+  }
+
+  beforeEach(() => {
+    getUserFromRequestMock.mockReset()
+    workOrderFindUniqueMock.mockReset()
+    stationFindFirstMock.mockReset()
+    woStageLogCreateMock.mockReset()
+  })
+
+  it('returns 200 and creates PAUSE log when valid data provided', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    stationFindFirstMock.mockResolvedValue(mockStation)
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-1' })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+        note: 'Taking a break',
+      })
+    )
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+    expect(payload.success).toBe(true)
+    expect(payload.message).toContain('Paused work on WO-2025-001')
+
+    // Verify WOStageLog creation with PAUSE event
+    expect(woStageLogCreateMock).toHaveBeenCalledWith({
+      data: {
+        workOrderId: 'wo-1',
+        routingStageId: 'stage-1',
+        stationId: 'station-1',
+        userId: 'user-1',
+        event: WOEvent.PAUSE,
+        note: 'Taking a break',
+      },
+    })
+  })
+
+  it('uses departmentId from query params when provided', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.SUPERVISOR,
+      departmentId: null,
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    stationFindFirstMock.mockResolvedValue(mockStation)
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-1' })
+
+    const response = await POST(
+      buildRequest(
+        {
+          workOrderId: 'wo-1',
+          stationId: 'station-1',
+        },
+        'dept-1'
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(woStageLogCreateMock).toHaveBeenCalled()
+  })
+
+  it('does not update work order status (PAUSE is just a log entry)', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    stationFindFirstMock.mockResolvedValue(mockStation)
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-1' })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(200)
+
+    // Verify WOStageLog created
+    expect(woStageLogCreateMock).toHaveBeenCalled()
+
+    // Note: No workOrderUpdate mock exists - pause doesn't change status
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    getUserFromRequestMock.mockReturnValue(null)
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Unauthorized' })
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when no department specified', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: null, // No department
+    })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'No department specified' })
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when work order not found', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(null)
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-nonexistent',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(404)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Work order not found' })
+    expect(woStageLogCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 when work order is on HOLD', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      status: WOStatus.HOLD,
+    })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(409)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Work order is already on hold' })
+    expect(woStageLogCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when user department does not match current stage', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-2', // Wrong department
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder) // Current stage is dept-1
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(403)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Not authorized for this stage' })
+    expect(woStageLogCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when station is invalid for current stage', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    stationFindFirstMock.mockResolvedValue(null) // Station not found
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'wrong-station',
+      })
+    )
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Invalid station' })
+    expect(woStageLogCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when no current stage found', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    // Work order with all stages disabled
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      routingVersion: {
+        ...mockWorkOrder.routingVersion,
+        stages: mockWorkOrder.routingVersion.stages.map((s) => ({ ...s, enabled: false })),
+      },
+    })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'No current stage found' })
+    expect(woStageLogCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('verifies station belongs to correct work center', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    stationFindFirstMock.mockResolvedValue(mockStation)
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-1' })
+
+    await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    // Verify station query includes work center validation
+    expect(stationFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        id: 'station-1',
+        workCenterId: 'wc-1', // Current stage's work center
+        isActive: true,
+      },
+    })
+  })
+
+  it('handles optional note parameter', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    stationFindFirstMock.mockResolvedValue(mockStation)
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-1' })
+
+    await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+        // No note provided
+      })
+    )
+
+    expect(woStageLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        note: null,
+      }),
+    })
+  })
+
+  it('returns 500 when workOrderId is missing', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    const response = await POST(
+      buildRequest({
+        stationId: 'station-1',
+        // Missing workOrderId
+      })
+    )
+
+    expect(response.status).toBe(500) // Zod validation error caught
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when stationId is missing', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        // Missing stationId
+      })
+    )
+
+    expect(response.status).toBe(500) // Zod validation error caught
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when database operation fails', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockRejectedValue(new Error('Database error'))
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(500)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Internal server error' })
+  })
+
+  it('allows pause from RELEASED status', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    const workOrderReleased = {
+      ...mockWorkOrder,
+      status: WOStatus.RELEASED,
+    }
+
+    workOrderFindUniqueMock.mockResolvedValue(workOrderReleased)
+    stationFindFirstMock.mockResolvedValue(mockStation)
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-1' })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-1',
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(woStageLogCreateMock).toHaveBeenCalled()
+  })
+
+  it('handles work order at second stage correctly', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-2',
+      role: Role.OPERATOR,
+      departmentId: 'dept-2', // Second department
+    })
+
+    const workOrderAtStage2 = {
+      ...mockWorkOrder,
+      currentStageIndex: 1, // Second stage
+    }
+
+    workOrderFindUniqueMock.mockResolvedValue(workOrderAtStage2)
+    stationFindFirstMock.mockResolvedValue({
+      id: 'station-2',
+      code: 'LAM-1',
+      workCenterId: 'wc-2',
+      isActive: true,
+    })
+    woStageLogCreateMock.mockResolvedValue({ id: 'log-2' })
+
+    const response = await POST(
+      buildRequest({
+        workOrderId: 'wo-1',
+        stationId: 'station-2',
+      })
+    )
+
+    expect(response.status).toBe(200)
+
+    // Verify correct stage used
+    expect(woStageLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        routingStageId: 'stage-2',
+      }),
+    })
+  })
+})

--- a/src/app/api/__tests__/work-orders.release.test.ts
+++ b/src/app/api/__tests__/work-orders.release.test.ts
@@ -1,0 +1,568 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { Role, WOStatus, RoutingVersionStatus } from '@prisma/client'
+
+const {
+  getUserFromRequestMock,
+  workOrderFindUniqueMock,
+  workOrderUpdateMock,
+  routingVersionUpdateMock,
+  workOrderVersionFindFirstMock,
+  workOrderVersionCreateMock,
+  auditLogCreateMock,
+  prismaTransactionMock,
+} = vi.hoisted(() => ({
+  getUserFromRequestMock: vi.fn(),
+  workOrderFindUniqueMock: vi.fn(),
+  workOrderUpdateMock: vi.fn(),
+  routingVersionUpdateMock: vi.fn(),
+  workOrderVersionFindFirstMock: vi.fn(),
+  workOrderVersionCreateMock: vi.fn(),
+  auditLogCreateMock: vi.fn(),
+  prismaTransactionMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getUserFromRequest: getUserFromRequestMock,
+}))
+
+vi.mock('@/server/db/client', () => ({
+  prisma: {
+    $transaction: prismaTransactionMock,
+    workOrder: {
+      findUnique: workOrderFindUniqueMock,
+      update: workOrderUpdateMock,
+    },
+    routingVersion: {
+      update: routingVersionUpdateMock,
+    },
+    auditLog: {
+      create: auditLogCreateMock,
+    },
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// Import after mocks
+import { POST } from '../work-orders/[id]/release/route'
+
+function buildRequest() {
+  return new NextRequest('https://example.com/api/work-orders/wo-1/release', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('POST /api/work-orders/[id]/release', () => {
+  const today = new Date()
+  const tomorrow = new Date(today)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  const dayAfter = new Date(tomorrow)
+  dayAfter.setDate(dayAfter.getDate() + 1)
+
+  const mockWorkOrder = {
+    id: 'wo-1',
+    number: 'WO-2025-001',
+    hullId: 'HULL-12345',
+    productSku: 'LX24-BASE',
+    qty: 1,
+    status: WOStatus.PLANNED,
+    priority: 'NORMAL',
+    plannedStartDate: tomorrow,
+    plannedFinishDate: dayAfter,
+    routingVersionId: 'routing-1',
+    currentStageIndex: 0,
+    specSnapshot: {
+      model: 'LX24',
+      trim: 'Base',
+      features: {},
+    },
+    routingVersion: {
+      id: 'routing-1',
+      model: 'LX24',
+      trim: 'Base',
+      version: 1,
+      status: RoutingVersionStatus.DRAFT,
+      stages: [
+        {
+          id: 'stage-1',
+          code: 'KITTING',
+          name: 'Kitting',
+          sequence: 1,
+          enabled: true,
+          workCenterId: 'wc-1',
+          standardStageSeconds: 3600,
+          workCenter: {
+            id: 'wc-1',
+            name: 'Kitting Center',
+            department: {
+              id: 'dept-1',
+              name: 'Assembly',
+            },
+          },
+        },
+      ],
+    },
+  }
+
+  beforeEach(() => {
+    getUserFromRequestMock.mockReset()
+    workOrderFindUniqueMock.mockReset()
+    workOrderUpdateMock.mockReset()
+    routingVersionUpdateMock.mockReset()
+    workOrderVersionFindFirstMock.mockReset()
+    workOrderVersionCreateMock.mockReset()
+    auditLogCreateMock.mockReset()
+    prismaTransactionMock.mockReset()
+  })
+
+  it('returns 200 and releases work order when valid supervisor request', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+
+    // Mock transaction callback
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      const tx = {
+        workOrderVersion: {
+          findFirst: workOrderVersionFindFirstMock,
+          create: workOrderVersionCreateMock,
+        },
+      }
+      return callback(tx)
+    })
+
+    workOrderVersionFindFirstMock.mockResolvedValue(null) // No existing versions
+    workOrderVersionCreateMock.mockResolvedValue({ id: 'version-1', versionNumber: 1 })
+    routingVersionUpdateMock.mockResolvedValue({ ...mockWorkOrder.routingVersion })
+    workOrderUpdateMock.mockResolvedValue({
+      ...mockWorkOrder,
+      status: WOStatus.RELEASED,
+    })
+    auditLogCreateMock.mockResolvedValue({ id: 'audit-1' })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+    expect(payload.success).toBe(true)
+    expect(payload.message).toContain('Work order WO-2025-001 released')
+    expect(payload.workOrder.status).toBe(WOStatus.RELEASED)
+
+    // Verify version snapshot created
+    expect(workOrderVersionCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workOrderId: 'wo-1',
+        versionNumber: 1,
+        reason: 'Work order released',
+        createdBy: 'supervisor@example.com',
+      }),
+    })
+
+    // Verify work order updated to RELEASED
+    expect(workOrderUpdateMock).toHaveBeenCalledWith({
+      where: { id: 'wo-1' },
+      data: expect.objectContaining({
+        status: WOStatus.RELEASED,
+        currentStageIndex: 0,
+      }),
+    })
+
+    // Verify audit log created
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorId: 'user-1',
+        model: 'WorkOrder',
+        modelId: 'wo-1',
+        action: 'RELEASE',
+      }),
+    })
+  })
+
+  it('allows ADMIN role to release work orders', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: Role.ADMIN,
+      departmentId: null,
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      const tx = {
+        workOrderVersion: {
+          findFirst: workOrderVersionFindFirstMock,
+          create: workOrderVersionCreateMock,
+        },
+      }
+      return callback(tx)
+    })
+    workOrderVersionFindFirstMock.mockResolvedValue(null)
+    workOrderVersionCreateMock.mockResolvedValue({ id: 'version-1', versionNumber: 1 })
+    routingVersionUpdateMock.mockResolvedValue({ ...mockWorkOrder.routingVersion })
+    workOrderUpdateMock.mockResolvedValue({ ...mockWorkOrder, status: WOStatus.RELEASED })
+    auditLogCreateMock.mockResolvedValue({ id: 'audit-1' })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('increments version number when previous versions exist', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      const tx = {
+        workOrderVersion: {
+          findFirst: workOrderVersionFindFirstMock,
+          create: workOrderVersionCreateMock,
+        },
+      }
+      return callback(tx)
+    })
+    workOrderVersionFindFirstMock.mockResolvedValue({ versionNumber: 2 }) // Version 2 exists
+    workOrderVersionCreateMock.mockResolvedValue({ id: 'version-3', versionNumber: 3 })
+    routingVersionUpdateMock.mockResolvedValue({ ...mockWorkOrder.routingVersion })
+    workOrderUpdateMock.mockResolvedValue({ ...mockWorkOrder, status: WOStatus.RELEASED })
+    auditLogCreateMock.mockResolvedValue({ id: 'audit-1' })
+
+    await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    // Verify version number is 3 (2 + 1)
+    expect(workOrderVersionCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        versionNumber: 3,
+      }),
+    })
+  })
+
+  it('updates routing version status from DRAFT to RELEASED', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      const tx = {
+        workOrderVersion: {
+          findFirst: workOrderVersionFindFirstMock,
+          create: workOrderVersionCreateMock,
+        },
+      }
+      return callback(tx)
+    })
+    workOrderVersionFindFirstMock.mockResolvedValue(null)
+    workOrderVersionCreateMock.mockResolvedValue({ id: 'version-1', versionNumber: 1 })
+    routingVersionUpdateMock.mockResolvedValue({
+      ...mockWorkOrder.routingVersion,
+      status: RoutingVersionStatus.RELEASED,
+    })
+    workOrderUpdateMock.mockResolvedValue({ ...mockWorkOrder, status: WOStatus.RELEASED })
+    auditLogCreateMock.mockResolvedValue({ id: 'audit-1' })
+
+    await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    // Verify routing version updated
+    expect(routingVersionUpdateMock).toHaveBeenCalledWith({
+      where: { id: 'routing-1' },
+      data: {
+        status: RoutingVersionStatus.RELEASED,
+        releasedAt: expect.any(Date),
+      },
+    })
+  })
+
+  it('does not update routing version if already RELEASED', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    const workOrderWithReleasedRouting = {
+      ...mockWorkOrder,
+      routingVersion: {
+        ...mockWorkOrder.routingVersion,
+        status: RoutingVersionStatus.RELEASED,
+      },
+    }
+
+    workOrderFindUniqueMock.mockResolvedValue(workOrderWithReleasedRouting)
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      const tx = {
+        workOrderVersion: {
+          findFirst: workOrderVersionFindFirstMock,
+          create: workOrderVersionCreateMock,
+        },
+      }
+      return callback(tx)
+    })
+    workOrderVersionFindFirstMock.mockResolvedValue(null)
+    workOrderVersionCreateMock.mockResolvedValue({ id: 'version-1', versionNumber: 1 })
+    workOrderUpdateMock.mockResolvedValue({ ...mockWorkOrder, status: WOStatus.RELEASED })
+    auditLogCreateMock.mockResolvedValue({ id: 'audit-1' })
+
+    await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    // Verify routing version NOT updated
+    expect(routingVersionUpdateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    getUserFromRequestMock.mockReturnValue(null)
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(401)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Unauthorized' })
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when user is OPERATOR (not supervisor/admin)', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      role: Role.OPERATOR,
+      departmentId: 'dept-1',
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(403)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Forbidden - Supervisor or Admin only' })
+    expect(workOrderFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when work order not found', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(null)
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-nonexistent' } })
+
+    expect(response.status).toBe(404)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Work order not found' })
+    expect(prismaTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when work order is not in PLANNED status', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      status: WOStatus.IN_PROGRESS,
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Work order must be in PLANNED status to release' })
+    expect(prismaTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when plannedStartDate is missing', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      plannedStartDate: null,
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      error: 'Cannot release work order without planned start and finish dates',
+    })
+    expect(prismaTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when plannedFinishDate is missing', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      plannedFinishDate: null,
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      error: 'Cannot release work order without planned start and finish dates',
+    })
+    expect(prismaTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when start date is not before finish date', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      plannedStartDate: dayAfter,
+      plannedFinishDate: tomorrow, // finish before start
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      error: 'Planned start date must be before planned finish date',
+    })
+    expect(prismaTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when start date is more than 1 day in the past', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    const twoDaysAgo = new Date(today)
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
+
+    workOrderFindUniqueMock.mockResolvedValue({
+      ...mockWorkOrder,
+      plannedStartDate: twoDaysAgo,
+      plannedFinishDate: tomorrow,
+    })
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(400)
+    const payload = await response.json()
+
+    expect(payload).toEqual({
+      error: 'Planned start date cannot be more than 1 day in the past',
+    })
+    expect(prismaTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('includes routing version snapshot in work order version', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockResolvedValue(mockWorkOrder)
+    prismaTransactionMock.mockImplementation(async (callback) => {
+      const tx = {
+        workOrderVersion: {
+          findFirst: workOrderVersionFindFirstMock,
+          create: workOrderVersionCreateMock,
+        },
+      }
+      return callback(tx)
+    })
+    workOrderVersionFindFirstMock.mockResolvedValue(null)
+    workOrderVersionCreateMock.mockResolvedValue({ id: 'version-1', versionNumber: 1 })
+    routingVersionUpdateMock.mockResolvedValue({ ...mockWorkOrder.routingVersion })
+    workOrderUpdateMock.mockResolvedValue({ ...mockWorkOrder, status: WOStatus.RELEASED })
+    auditLogCreateMock.mockResolvedValue({ id: 'audit-1' })
+
+    await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    // Verify snapshot includes routing version details
+    expect(workOrderVersionCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        snapshotData: expect.objectContaining({
+          status: 'RELEASED',
+          routingVersion: expect.objectContaining({
+            model: 'LX24',
+            trim: 'Base',
+            version: 1,
+            stages: expect.arrayContaining([
+              expect.objectContaining({
+                code: 'KITTING',
+                name: 'Kitting',
+              }),
+            ]),
+          }),
+        }),
+      }),
+    })
+  })
+
+  it('returns 500 when database operation fails', async () => {
+    getUserFromRequestMock.mockReturnValue({
+      userId: 'user-1',
+      email: 'supervisor@example.com',
+      role: Role.SUPERVISOR,
+      departmentId: 'dept-1',
+    })
+
+    workOrderFindUniqueMock.mockRejectedValue(new Error('Database error'))
+
+    const response = await POST(buildRequest(), { params: { id: 'wo-1' } })
+
+    expect(response.status).toBe(500)
+    const payload = await response.json()
+
+    expect(payload).toEqual({ error: 'Internal server error' })
+  })
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -28,6 +28,11 @@ const fallbackEnums = {
     COMPLETE: 'COMPLETE',
     RESUME: 'RESUME',
   } as const,
+  RoutingVersionStatus: {
+    DRAFT: 'DRAFT',
+    RELEASED: 'RELEASED',
+    ARCHIVED: 'ARCHIVED',
+  } as const,
 }
 
 vi.mock('@prisma/client', async () => {
@@ -42,11 +47,13 @@ vi.mock('@prisma/client', async () => {
         WOStatus: actual.Prisma?.WOStatus ?? fallbackEnums.WOStatus,
         WOPriority: actual.Prisma?.WOPriority ?? fallbackEnums.WOPriority,
         WOEvent: actual.Prisma?.WOEvent ?? fallbackEnums.WOEvent,
+        RoutingVersionStatus: actual.Prisma?.RoutingVersionStatus ?? fallbackEnums.RoutingVersionStatus,
       },
       Role: actual.Role ?? fallbackEnums.Role,
       WOStatus: actual.WOStatus ?? fallbackEnums.WOStatus,
       WOPriority: actual.WOPriority ?? fallbackEnums.WOPriority,
       WOEvent: actual.WOEvent ?? fallbackEnums.WOEvent,
+      RoutingVersionStatus: actual.RoutingVersionStatus ?? fallbackEnums.RoutingVersionStatus,
     }
   } catch (error) {
     return {
@@ -62,11 +69,13 @@ vi.mock('@prisma/client', async () => {
         WOStatus: fallbackEnums.WOStatus,
         WOPriority: fallbackEnums.WOPriority,
         WOEvent: fallbackEnums.WOEvent,
+        RoutingVersionStatus: fallbackEnums.RoutingVersionStatus,
       },
       Role: fallbackEnums.Role,
       WOStatus: fallbackEnums.WOStatus,
       WOPriority: fallbackEnums.WOPriority,
       WOEvent: fallbackEnums.WOEvent,
+      RoutingVersionStatus: fallbackEnums.RoutingVersionStatus,
     }
   }
 })


### PR DESCRIPTION
Phase 3 expands test coverage from 20 to 26 routes (47% coverage), adding 79 new tests for work order state transitions, data retrieval, and authentication endpoints.

Test Files Created:
- work-orders.pause.test.ts (17 tests): PAUSE event logging, no status change, dept scoping
- work-orders.release.test.ts (15 tests): PLANNED→RELEASED, RBAC, date validation, versions
- work-orders.list.test.ts (11 tests): pagination, cursor support, ordering, all roles
- work-orders.detail.test.ts (15 tests): dept scoping, nested includes, stage timeline
- auth.logout.test.ts (8 tests): cookie clearing, httpOnly/secure/sameSite, idempotent
- auth.me.test.ts (13 tests): token verification, user info, error handling, security

Test Setup:
- Added RoutingVersionStatus enum to vitest.setup.ts fallbackEnums

Results:
- Total tests: 220 (up from 141, +56% increase)
- Test files: 20 (up from 14)
- Routes covered: 26 of 55 (47%)
- All tests passing

Updated:
- docs/ActionItems.md: Phase 3 complete, updated coverage stats
- docs/CHANGELOG.md: 2026-01-13T14:33:54Z entry with full details